### PR TITLE
Fix logout token key

### DIFF
--- a/frontend/src/components/HeaderAdmin.jsx
+++ b/frontend/src/components/HeaderAdmin.jsx
@@ -8,7 +8,7 @@ export default function HeaderAdmin() {
 
   const handleLogout = () => {
     // Clear token & redirect
-    localStorage.removeItem('authToken');
+    localStorage.removeItem('token');
     navigate('/login');
   };
 


### PR DESCRIPTION
## Summary
- remove localStorage `authToken` key reference in HeaderAdmin

## Testing
- `grep -R "authToken" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_68860f0336488328a1ee6ddff16e676d