### PR TITLE
Use Jakarta timezone for countdown timer

### DIFF
--- a/frontend/src/components/CountdownTimer.jsx
+++ b/frontend/src/components/CountdownTimer.jsx
@@ -1,10 +1,15 @@
 import { useEffect, useState } from 'react';
 
+const getJakartaNow = () =>
+  new Date(
+    new Date().toLocaleString('en-US', { timeZone: 'Asia/Jakarta' })
+  ).getTime();
+
 export default function CountdownTimer({ targetDate }) {
-  const [now, setNow] = useState(Date.now());
+  const [now, setNow] = useState(getJakartaNow());
 
   useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 1000);
+    const id = setInterval(() => setNow(getJakartaNow()), 1000);
     return () => clearInterval(id);
   }, []);
 


### PR DESCRIPTION
## Summary
- ensure countdown timer uses Asia/Jakarta time rather than local Date.now

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895a990d3288328ab1fd30c640668ad