### PR TITLE
Replace cron with dynamic scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Platform hasil undian kota-kota di Indonesia.
 2. Jalankan `docker-compose up --build`.
 3. Akses frontend di `http://localhost:3000` dan backend API di `http://localhost:4000`.
 
+## Scheduler Hasil Undian
+
+Untuk menghasilkan hasil undian secara otomatis, jalankan scheduler di folder `backend`:
+
+```bash
+cd backend
+node src/cron/fetchResults.js
+```
+
+Scheduler menggunakan loop `setTimeout` untuk membaca jadwal dari tabel `Schedule` dan menjalankan proses penarikan pada waktu berikutnya secara terus menerus.
+
 ## Menambah Kota Baru
 
 Gunakan halaman Admin untuk menambah kota baru. Setiap tengah malam server akan membuat hasil undian otomatis.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,6 @@
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "node-cron": "^4.2.0",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
@@ -1069,15 +1068,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-cron": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.0.tgz",
-      "integrity": "sha512-nOdP7uH7u55w7ybQq9fusXtsResok+ErzvOBydJUPBBaQ9W+EfBaBWFPgJ8sOB7FWQednDvVBJtgP5xA0bME7Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,6 @@
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "node-cron": "^4.2.0",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {

--- a/backend/src/cron/fetchResults.js
+++ b/backend/src/cron/fetchResults.js
@@ -1,36 +1,64 @@
-// const cron = require('node-cron');
-// const prisma = require('../config/database');
+const prisma = require('../config/database');
 
-// function generateNumbers() {
-//   return Array.from({ length: 6 }, () => Math.floor(Math.random() * 49) + 1).join(',');
-// }
+function jakartaNow() {
+  const now = new Date();
+  const utc = now.getTime() + now.getTimezoneOffset() * 60000;
+  return new Date(utc + 7 * 3600000);
+}
 
-// async function run() {
-//   const now = new Date();
-//   const schedules = await prisma.schedule.findMany();
-//   for (const s of schedules) {
-//     if (!s.drawTime) continue;
-//     const [hour, minute] = s.drawTime.split(':').map(Number);
-//     const drawDate = new Date(now);
-//     drawDate.setHours(hour, minute, 0, 0);
-//     if (drawDate > now) drawDate.setDate(drawDate.getDate() - 1);
-//     const existing = await prisma.lotteryResult.findUnique({
-//       where: { city_drawDate: { city: s.city, drawDate } },
-//     });
-//     if (!existing && now >= drawDate) {      await prisma.lotteryResult.create({
-//         data: {
-//           city: s.city,
-//           drawDate,
-//           numbers: generateNumbers(),
-//         },
-//       });
-//       const next = new Date(s.nextDraw.getTime() + 24 * 60 * 60 * 1000);
-//       await prisma.schedule.update({ where: { city: s.city }, data: { nextDraw: next } });
-//     }
-//   }
-//   console.log('Draw job executed at', now);
-// }
+function generateNumber() {
+  return String(Math.floor(Math.random() * 1000000)).padStart(6, '0');
+}
 
-// cron.schedule('* * * * *', run); // check every minute
+async function run() {
+  const now = jakartaNow();
+  const schedules = await prisma.schedule.findMany();
+  for (const s of schedules) {
+    if (!s.drawTime) continue;
+    const [hour, minute] = s.drawTime.split(':').map(Number);
+    const drawDate = new Date(now);
+    drawDate.setHours(hour, minute, 0, 0);
+    if (drawDate > now) drawDate.setDate(drawDate.getDate() - 1);
+    const existing = await prisma.lotteryResult.findUnique({
+      where: { city_drawDate: { city: s.city, drawDate } },
+    });
+    if (!existing && now >= drawDate) {
+      await prisma.lotteryResult.create({
+        data: {
+          city: s.city,
+          drawDate,
+          firstPrize: generateNumber(),
+          secondPrize: generateNumber(),
+          thirdPrize: generateNumber(),
+        },
+      });
+    }
+  }
+  console.log('Draw job executed at', now);
+}
 
-// module.exports = { run };
+async function scheduleNext() {
+  const now = jakartaNow();
+  const schedules = await prisma.schedule.findMany();
+  let nextDraw = null;
+  for (const s of schedules) {
+    if (!s.drawTime) continue;
+    const [hour, minute] = s.drawTime.split(':').map(Number);
+    const candidate = new Date(now);
+    candidate.setHours(hour, minute, 0, 0);
+    if (candidate <= now) candidate.setDate(candidate.getDate() + 1);
+    if (!nextDraw || candidate < nextDraw) nextDraw = candidate;
+  }
+  const delay = nextDraw ? nextDraw.getTime() - now.getTime() : 60 * 1000;
+  setTimeout(async () => {
+    await run();
+    scheduleNext();
+  }, delay);
+}
+
+if (require.main === module) {
+  scheduleNext();
+}
+
+module.exports = { run, scheduleNext };
+


### PR DESCRIPTION
## Summary
- implement setTimeout loop that schedules draws based on prisma schedule
- remove node-cron dependency and document new scheduler usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895a994c8f083288140d6024c1392a0