### PR TITLE
Validate lottery draw time format

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -27,6 +27,10 @@ exports.latestByCity = async (req, res) => {
     const schedule = await prisma.schedule.findUnique({ where: { city } });
     let nextDraw = null;
     if (schedule?.drawTime) {
+      if (!/^\d{2}:\d{2}$/.test(schedule.drawTime)) {
+        console.error(`Invalid drawTime format for city ${city}: ${schedule.drawTime}`);
+        return res.status(400).json({ message: 'Invalid drawTime format' });
+      }
       const [hour, minute] = schedule.drawTime.split(':').map(Number);
       const now = jakartaDate();
       const next = new Date(now);


### PR DESCRIPTION
## Summary
- ensure `latestByCity` validates schedule draw time format and logs errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ad3987108328a857630249aad0a7