### PR TITLE
refactor: remove hardcoded api url

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,6 @@
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
+const baseUrl =
+  import.meta.env.VITE_API_URL || import.meta.env.VITE_SOCKET_URL || '';
+const API_URL = `${baseUrl}/api`;
 
 export async function fetchPools() {
   const res = await fetch(`${API_URL}/pools`);


### PR DESCRIPTION
## Summary
- use environment vars for frontend API base URL

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895b0ea92808328b83621364805fec0