### PR TITLE
Add schedule validation and tests for lottery endpoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "build": "prisma generate",
     "start": "node src/app.js",
     "dev": "nodemon src/app.js",
-    "seed": "node prisma/seed.js"
+    "seed": "node prisma/seed.js",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/backend/test/lottery.controller.test.js
+++ b/backend/test/lottery.controller.test.js
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+
+function loadController(mockPrisma) {
+  const dbPath = path.resolve(__dirname, '../src/config/database.js');
+  const ctrlPath = path.resolve(__dirname, '../src/controllers/lottery.controller.js');
+  // Inject mock prisma into require cache before requiring controller
+  require.cache[dbPath] = { exports: mockPrisma };
+  delete require.cache[ctrlPath];
+  return require(ctrlPath);
+}
+
+test('latestByCity returns 404 when schedule is missing', async () => {
+  const mockPrisma = {
+    lotteryResult: {
+      findFirst: async () => ({ city: 'jakarta', drawDate: new Date(), firstPrize: '', secondPrize: '', thirdPrize: '' })
+    },
+    schedule: {
+      findUnique: async () => null
+    }
+  };
+  const ctrl = loadController(mockPrisma);
+  const req = { params: { city: 'jakarta' } };
+  let statusCode, body;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(obj) { body = obj; }
+  };
+  await ctrl.latestByCity(req, res);
+  assert.equal(statusCode, 404);
+  assert.deepEqual(body, { message: 'Schedule not found' });
+});
+
+test('latestByCity returns 400 when drawTime is invalid', async () => {
+  const mockPrisma = {
+    lotteryResult: {
+      findFirst: async () => ({ city: 'jakarta', drawDate: new Date(), firstPrize: '', secondPrize: '', thirdPrize: '' })
+    },
+    schedule: {
+      findUnique: async () => ({ city: 'jakarta', drawTime: '99:99' })
+    }
+  };
+  const ctrl = loadController(mockPrisma);
+  const req = { params: { city: 'jakarta' } };
+  let statusCode, body;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(obj) { body = obj; }
+  };
+  await ctrl.latestByCity(req, res);
+  assert.equal(statusCode, 400);
+  assert.deepEqual(body, { message: 'Invalid drawTime value' });
+});


### PR DESCRIPTION
## Summary
- validate schedule existence and drawTime format when fetching latest lottery results
- log and return 400/404 instead of 500 for invalid or missing schedule data
- add Node tests covering missing schedule and invalid drawTime cases

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895b322bb6883289086cc6f532f1383