### PR TITLE
Remove duplicate logFetchError export

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -157,9 +157,6 @@ exports.authMiddleware = (req, res, next) => {
     res.status(401).json({ message: 'Invalid token' });
   }
 };
-exports.logFetchError = async (city, message) => {
-  await prisma.fetchError.create({ data: { city, message } });
-};
 exports.listAllHistory = async (req, res) => {
   try {
     const records = await prisma.lotteryResult.findMany({


### PR DESCRIPTION
## Summary
- remove duplicate `logFetchError` export in lottery controller
- ensure only a single `logFetchError` definition remains

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895b327e9108328a7c645e15ca414b8