### PR TITLE
Use env-sourced socket URL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:4000/api
+VITE_SOCKET_URL=http://localhost:4000

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -16,7 +16,10 @@ export default function Home() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    const socket = socketIO(import.meta.env.VITE_SOCKET_URL || 'http://localhost:4000');
+    const apiOrigin = import.meta.env.VITE_API_URL
+      ? new URL(import.meta.env.VITE_API_URL).origin
+      : undefined;
+    const socket = socketIO(import.meta.env.VITE_SOCKET_URL || apiOrigin);
     socket.on('resultUpdated', async ({ city }) => {
       try {
         const latest = await fetchLatest(city);

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "VITE_SOCKET_URL": "https://example.com"
+  },
   "rewrites": [
     { "source": "/(.*)", "destination": "/" }
   ]


### PR DESCRIPTION
## Summary
- derive socket connection origin from build-time environment instead of hardcoded localhost
- provide example env file and deployment config defining `VITE_SOCKET_URL`

## Testing
- `npm test` (backend)
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6895b60ce1848328aa06a025aff00f35