### PR TITLE
feat: improve lottery error handling

### DIFF
--- a/backend/test/lottery.controller.test.js
+++ b/backend/test/lottery.controller.test.js
@@ -29,7 +29,7 @@ test('latestByCity returns 404 when schedule is missing', async () => {
   };
   await ctrl.latestByCity(req, res);
   assert.equal(statusCode, 404);
-  assert.deepEqual(body, { message: 'Schedule not found' });
+  assert.deepEqual(body, { error: 'schedule missing' });
 });
 
 test('latestByCity returns 400 when drawTime is invalid', async () => {


### PR DESCRIPTION
## Summary
- clarify missing result or schedule with 404 error messages
- log database outages and return 503 without crashing
- adjust tests for new error responses

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895b6078e788328a81f81f8cedc5377