### PR TITLE
Add batch lottery latest results endpoint and frontend integration

### DIFF
--- a/backend/src/routes/lottery.routes.js
+++ b/backend/src/routes/lottery.routes.js
@@ -5,6 +5,7 @@ const router  = express.Router();
 
 // Public endpoints
 router.get('/pools',               ctrl.listPools);
+router.get('/pools/latest',        ctrl.latestMany);
 router.get('/pools/:city/latest',  ctrl.latestByCity);
 router.get('/history', ctrl.listAllHistory);
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -6,7 +6,7 @@ import Header from '../components/Header';
 import Footer from '../components/Footer';
 import CityPoolCard from '../components/CityPoolCard';
 import CountdownTimer from '../components/CountdownTimer';
-import { fetchPools, fetchLatest } from '../services/api';
+import { fetchPools, fetchLatest, fetchAllLatest } from '../services/api';
 
 export default function Home() {
   const [cities, setCities] = useState([]);
@@ -42,26 +42,9 @@ export default function Home() {
         setCities(cityList);
         if (cityList.length) setSelectedCity(cityList[0]);
 
-        const settled = await Promise.allSettled(
-          cityList.map((city) => fetchLatest(city))
-        );
-
-        const successEntries = [];
-        const errorMessages = [];
-
-        settled.forEach((res, idx) => {
-          const city = cityList[idx];
-          if (res.status === 'fulfilled') {
-            successEntries.push([city, res.value]);
-          } else {
-            errorMessages.push(
-              `Failed to load ${city}: ${res.reason?.message || res.reason}`
-            );
-          }
-        });
-
-        setResults(Object.fromEntries(successEntries));
-        setError(errorMessages.length ? errorMessages.join('; ') : null);
+        const data = await fetchAllLatest(cityList);
+        setResults(Object.fromEntries(data.map((item) => [item.city, item])));
+        setError(null);
       } catch (err) {
         console.error('Failed to load pools:', err);
         setError(err.message || 'Failed to load data');

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -20,6 +20,21 @@ export async function fetchLatest(city) {
     nextDraw: data.nextDraw,
   };
 }
+
+export async function fetchAllLatest(cities = []) {
+  const url = new URL(`${API_URL}/pools/latest`);
+  if (cities.length) url.searchParams.set('cities', cities.join(','));
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
+  const data = await res.json();
+  return data.map((item) => ({
+    ...item,
+    numbers: [item.firstPrize, item.secondPrize, item.thirdPrize],
+    nextDraw: item.nextDraw,
+  }));
+}
 // Admin
 export async function adminLogin(username, password) {
   const res = await fetch(`${API_URL}/admin/login`, {


### PR DESCRIPTION
## Summary
- add `GET /pools/latest` backend endpoint to fetch many cities in one query
- expose `fetchAllLatest` service and update Home to call it once

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895bb8dc048832882b6fcf3b68cde2a