### PR TITLE
Handle pool fetch errors

### DIFF
--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -58,7 +58,9 @@ export default function Admin() {
       .catch(err => console.error(err));
     fetchPools(token)
       .then(data => setPools(data))
-      .catch(err => console.error(err));
+      .catch(err =>
+        setMessage({ text: err.message || 'Gagal memuat daftar kota', type: 'error' })
+      );
     fetchRecentOverrides(token)
       .then(data => setOverrides(Array.isArray(data) ? data : []))
       .catch(err => console.error(err));

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -64,7 +64,7 @@ export default function Home() {
         setError(errorMessages.length ? errorMessages.join('; ') : null);
       } catch (err) {
         console.error('Failed to load pools:', err);
-        setError(err.message || 'Failed to load data');
+        setError(`Failed to load pools: ${err.message || 'Unknown error'}`);
       } finally {
         setLoading(false);
       }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -4,6 +4,9 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
 // Public
 export async function fetchPools() {
   const res = await fetch(`${API_URL}/pools`);
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
   return res.json();
 }
 


### PR DESCRIPTION
## Summary
- Throw an error when `fetchPools` receives a non-OK response
- Surface fetch failures in `Home` and `Admin` pages with user-visible messages

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm test` (backend)`

------
https://chatgpt.com/codex/tasks/task_e_6895bba0e5048328825edbe502614e45