### PR TITLE
Expose schedule times and update frontend

### DIFF
--- a/backend/test/lottery.controller.test.js
+++ b/backend/test/lottery.controller.test.js
@@ -38,7 +38,7 @@ test('latestByCity returns 400 when drawTime is invalid', async () => {
       findFirst: async () => ({ city: 'jakarta', drawDate: new Date(), firstPrize: '', secondPrize: '', thirdPrize: '' })
     },
     schedule: {
-      findUnique: async () => ({ city: 'jakarta', drawTime: '99:99' })
+      findUnique: async () => ({ city: 'jakarta', drawTime: '99:99', closeTime: '10:00' })
     }
   };
   const ctrl = loadController(mockPrisma);

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -56,8 +56,10 @@ export default function Home() {
   }, []);
 
   const heroData = results[selectedCity] || {};
+  const heroNextClose = heroData.nextClose ? new Date(heroData.nextClose) : null;
   const heroNextDraw = heroData.nextDraw ? new Date(heroData.nextDraw) : null;
-  const showCountdown = heroNextDraw instanceof Date && !isNaN(heroNextDraw.valueOf());
+  const showCountdown =
+    heroNextClose instanceof Date && !isNaN(heroNextClose.valueOf());
 
   const heroNumbers = [
     heroData.firstPrize,
@@ -89,13 +91,14 @@ export default function Home() {
             </h1>
 
             {showCountdown
-              ? <CountdownTimer targetDate={heroNextDraw} />
+              ? <CountdownTimer targetDate={heroNextClose} />
               : <div className="h-12 w-48 bg-gray-700 animate-pulse rounded-md" />
             }
 
             {showCountdown && (
               <p className="text-sm text-gray-300">
-                {heroNextDraw.toLocaleString('id-ID', {
+                Tutup:{' '}
+                {heroNextClose.toLocaleString('id-ID', {
                   weekday: 'long',
                   day: 'numeric',
                   month: 'long',
@@ -103,8 +106,19 @@ export default function Home() {
                   hour: '2-digit',
                   minute: '2-digit',
                   timeZoneName: 'short',
-                                    timeZone: 'Asia/Jakarta',
-
+                  timeZone: 'Asia/Jakarta',
+                })}
+                <br />
+                Undian:{' '}
+                {heroNextDraw?.toLocaleString('id-ID', {
+                  weekday: 'long',
+                  day: 'numeric',
+                  month: 'long',
+                  year: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  timeZoneName: 'short',
+                  timeZone: 'Asia/Jakarta',
                 })}
               </p>
             )}

--- a/frontend/src/pages/SchedulePage.jsx
+++ b/frontend/src/pages/SchedulePage.jsx
@@ -26,10 +26,31 @@ export default function SchedulePage() {
             </thead>
             <tbody>
               {schedules.map((s, i) => (
-                <tr key={s.city} className={i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                <tr
+                  key={s.city}
+                  className={i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}
+                >
                   <td className="px-4 py-2">{s.city}</td>
-                  <td className="px-4 py-2">{s.closeTime}</td>
-                  <td className="px-4 py-2">{s.drawTime}</td>
+                  <td className="px-4 py-2">
+                    {new Date(`1970-01-01T${s.closeTime}:00+07:00`).toLocaleTimeString(
+                      'id-ID',
+                      {
+                        timeZone: 'Asia/Jakarta',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      },
+                    )}
+                  </td>
+                  <td className="px-4 py-2">
+                    {new Date(`1970-01-01T${s.drawTime}:00+07:00`).toLocaleTimeString(
+                      'id-ID',
+                      {
+                        timeZone: 'Asia/Jakarta',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      },
+                    )}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -18,6 +18,7 @@ export async function fetchLatest(city) {
     ...data,
     numbers: [data.firstPrize, data.secondPrize, data.thirdPrize],
     nextDraw: data.nextDraw,
+    nextClose: data.nextClose,
   };
 }
 
@@ -33,6 +34,7 @@ export async function fetchAllLatest(cities = []) {
     ...item,
     numbers: [item.firstPrize, item.secondPrize, item.thirdPrize],
     nextDraw: item.nextDraw,
+    nextClose: item.nextClose,
   }));
 }
 // Admin


### PR DESCRIPTION
## Summary
- compute and return `nextClose` alongside `nextDraw` for lottery results
- propagate new schedule fields through API helpers and home page hero
- display schedule times in Jakarta timezone on schedule page

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test` *(fails: Missing script: "test")*
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_6895c1cee7a883289f19ed51dc1e4496