### PR TITLE
feat: add live draw socket orchestration

### DIFF
--- a/backend/src/io.js
+++ b/backend/src/io.js
@@ -2,6 +2,10 @@ let ioInstance;
 
 function init(io) {
   ioInstance = io;
+  io.on('connection', (socket) => {
+    console.log('Client connected', socket.id);
+    socket.on('disconnect', () => console.log('Client disconnected', socket.id));
+  });
 }
 
 function getIO() {

--- a/backend/src/routes/lottery.routes.js
+++ b/backend/src/routes/lottery.routes.js
@@ -8,6 +8,7 @@ router.get('/pools',               ctrl.listPools);
 router.get('/pools/latest',        ctrl.latestMany);
 router.get('/pools/:city/latest',  ctrl.latestByCity);
 router.get('/history', ctrl.listAllHistory);
+router.post('/pools/:city/live-draw', ctrl.authMiddleware, ctrl.startLiveDraw);
 
 // Admin login
 router.post('/admin/login',        ctrl.login);


### PR DESCRIPTION
## Summary
- add `startLiveDraw` controller to sequentially emit draw results
- expose POST `/pools/:city/live-draw` endpoint to start draws
- initialise socket.io connections for live draw broadcasting

## Testing
- `cd backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6895d65232148328a9210400be98af70