### PR TITLE
Link header live draw buttons to new page

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -27,12 +27,15 @@ export default function Header() {
           <Link to="/schedule" className="hover:text-gold transition">Jadwal</Link>
 
           <Link to="/about" className="hover:text-gold transition">Tentang Kami</Link>
-          <button className="bg-red-600 hover:bg-red-700 px-4 py-1 rounded-lg flex items-center space-x-1 transition">
+          <Link
+            to="/live"
+            className="bg-red-600 hover:bg-red-700 px-4 py-1 rounded-lg flex items-center space-x-1 transition"
+          >
             <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
               <path d="M10 16.5l6-4.5-6-4.5v9z" />
             </svg>
-            <span>Live Streaming</span>
-          </button>
+            <span>Live Draw</span>
+          </Link>
 
         </nav>
 
@@ -48,22 +51,32 @@ export default function Header() {
       {/* Mobile Nav */}
       {open && (
         <nav className="md:hidden bg-primary bg-opacity-90 text-white px-4 pb-4 space-y-2">
-          {['Beranda','Lucky Number','Previous Results','Statistics','Schedule','About Us','How To Play'].map((label) => (
+          {[
+            { label: 'Beranda', to: '/' },
+            { label: 'Generate Nomor', to: '/lucky' },
+            { label: 'Hasil Sebelumnya', to: '/stats' },
+            { label: 'Jadwal', to: '/schedule' },
+            { label: 'Tentang Kami', to: '/about' },
+          ].map(({ label, to }) => (
             <Link
               key={label}
-              to={`/${label.toLowerCase().replace(/ /g,'')}`}
+              to={to}
               className="block py-2 hover:text-gold transition"
               onClick={() => setOpen(false)}
             >
               {label}
             </Link>
           ))}
-          <button className="w-full text-left bg-red-600 hover:bg-red-700 px-4 py-2 rounded-lg flex items-center space-x-1 transition">
+          <Link
+            to="/live"
+            className="w-full text-left bg-red-600 hover:bg-red-700 px-4 py-2 rounded-lg flex items-center space-x-1 transition"
+            onClick={() => setOpen(false)}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
               <path d="M10 16.5l6-4.5-6-4.5v9z" />
             </svg>
-            <span>Live Streaming</span>
-          </button>
+            <span>Live Draw</span>
+          </Link>
           <div className="flex items-center space-x-2 pt-2">
             <img src="/flags/id.svg" alt="ID" className="w-5 h-5" />
             <span>ID</span>


### PR DESCRIPTION
## Summary
- Replace desktop and mobile Live Streaming buttons with `<Link to="/live">`
- Align mobile navigation labels and routes, including new Live Draw link

## Testing
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895d65c07e8832898ccdba893cc0ff9