### PR TITLE
feat: add multi-prize live draw

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Scheduler menggunakan loop `setTimeout` untuk membaca jadwal dari tabel `Schedul
 
 Beberapa menit sebelum waktu undian (`drawTime`), scheduler juga memanggil fungsi `startLiveDraw(city)` untuk menandai bahwa proses undian sedang berlangsung. Fitur ini memastikan bahwa undian langsung dimulai tepat waktu tanpa duplikasi jika scheduler dijalankan lebih dari sekali.
 
+## Live Draw Manual
+
+Admin dapat memulai sesi live draw secara manual melalui endpoint:
+
+```
+POST /api/pools/:city/live-draw
+```
+
+Server akan mengirim tiga ronde hadiah (pertama, kedua, ketiga) melalui Socket.IO. Event `prizeStart` menandakan ronde baru dan `drawNumber` mengirim setiap digit hadiah secara berurutan.
+
 ## Menambah Kota Baru
 
 Gunakan halaman Admin untuk menambah kota baru. Setiap tengah malam server akan membuat hasil undian otomatis.

--- a/backend/src/io.js
+++ b/backend/src/io.js
@@ -4,6 +4,14 @@ function init(io) {
   ioInstance = io;
   io.on('connection', (socket) => {
     console.log('Client connected', socket.id);
+    // Allow clients to join a room based on city so we can emit
+    // live draw events to the relevant audience only.
+    socket.on('joinLive', (city) => {
+      if (socket.currentRoom) socket.leave(socket.currentRoom);
+      socket.join(city);
+      socket.currentRoom = city;
+    });
+
     socket.on('disconnect', () => console.log('Client disconnected', socket.id));
   });
 }


### PR DESCRIPTION
## Summary
- support joining live draw rooms per city
- emit three prize rounds via Socket.IO for each live draw
- update frontend to display prize rounds and reset balls
- document manual live draw API usage

## Testing
- `npm test` in `backend`
- `npm test` (fails: Missing script: "test") in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6895dac859c88328aaef039d5c43dd7d