### PR TITLE
Make city selector responsive

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -125,12 +125,12 @@ export default function Home() {
 
             {/* Custom City Selector */}
             <Listbox value={selectedCity} onChange={setSelectedCity}>
-              <div className="relative mt-2 w-64">
+              <div className="relative mt-2 w-full max-w-xs sm:max-w-sm">
                 <Listbox.Button className="relative w-full cursor-pointer bg-gray-700 text-white py-2 pl-4 pr-10 text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-primary">
                   <span className="block truncate">{selectedCity || 'Pilih Kota'}</span>
- <span className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
-   <ChevronUpDownIcon className="h-5 w-5 text-gray-300" />
- </span>
+                  <span className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
+                    <ChevronUpDownIcon className="h-5 w-5 text-gray-300" />
+                  </span>
                 </Listbox.Button>
 
                 <Transition

--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -108,7 +108,7 @@ export default function LiveDrawPage() {
     <div className="flex flex-col min-h-screen bg-gradient-to-br from-red-900 via-red-800 to-red-900 text-gray-100">
       <Header />
       <main className="flex-1 flex flex-col items-center justify-center px-4 py-12 space-y-8">
-        <div className="w-64">
+        <div className="w-full max-w-xs sm:max-w-sm">
           <Listbox value={selectedCity} onChange={setSelectedCity}>
             <div className="relative">
               <Listbox.Button className="relative w-full cursor-pointer bg-gray-700 text-white py-2 pl-4 pr-10 text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-primary">


### PR DESCRIPTION
## Summary
- Make city selector responsive in Home and LiveDraw pages by using `w-full max-w-xs sm:max-w-sm` wrappers
- Preserve `w-full` on `Listbox.Button` for full width

## Testing
- `npm test` *(frontend: missing script)*
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895df34c5dc83288b157614d7a59dd7