### PR TITLE
Expose schedule data with pool listing

### DIFF
--- a/backend/test/lottery.controller.test.js
+++ b/backend/test/lottery.controller.test.js
@@ -52,3 +52,29 @@ test('latestByCity returns 400 when drawTime is invalid', async () => {
   assert.equal(statusCode, 400);
   assert.deepEqual(body, { message: 'Invalid drawTime value' });
 });
+
+test('listPools returns schedule info', async () => {
+  const mockPrisma = {
+    lotteryResult: {
+      findMany: async () => [{ city: 'jakarta' }, { city: 'bandung' }],
+    },
+    schedule: {
+      findMany: async () => [
+        { city: 'jakarta', drawTime: '10:00', closeTime: '09:00' },
+      ],
+    },
+  };
+  const ctrl = loadController(mockPrisma);
+  let body;
+  const res = { json(obj) { body = obj; } };
+  await ctrl.listPools({}, res);
+  assert.equal(Array.isArray(body), true);
+  assert.equal(body.length, 2);
+  const jakarta = body.find((c) => c.city === 'jakarta');
+  assert.ok(jakarta.startsAt);
+  assert.ok(Date.parse(jakarta.startsAt));
+  assert.strictEqual(typeof jakarta.isLive, 'boolean');
+  const bandung = body.find((c) => c.city === 'bandung');
+  assert.equal(bandung.startsAt, null);
+  assert.equal(bandung.isLive, false);
+});

--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -195,16 +195,15 @@ export default function LiveDrawPage() {
   const [tickerItems, setTickerItems] = useState([]);
   const socketRef = useRef(null);
 
-  // --- Normalize city item (support string OR object) ---
+  // --- Normalize city item coming from API ({ city, startsAt, isLive }) ---
   const normalizeCity = (item) => {
     if (!item) return null;
     if (typeof item === 'string') {
       return { id: item, name: item, startsAt: null, isLive: false };
     }
-    // expected shape: { id, name, startsAt, isLive, ... }
     return {
-      id: item.id ?? item.name ?? item.city ?? JSON.stringify(item),
-      name: item.name ?? item.city ?? 'Unknown',
+      id: item.city || item.id || item.name || JSON.stringify(item),
+      name: item.city || item.name || 'Unknown',
       startsAt: parseDate(item.startsAt) || null,
       isLive: Boolean(item.isLive),
       raw: item,
@@ -228,7 +227,7 @@ export default function LiveDrawPage() {
   // --- Initial fetch + pick best city (live or nearest) ---
   useEffect(() => {
     async function load() {
-      const list = await fetchPools(); // can return strings or objects
+      const list = await fetchPools();
       setCities(Array.isArray(list) ? list : []);
     }
     load();

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -4,7 +4,12 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
 // Public
 export async function fetchPools() {
   const res = await fetch(`${API_URL}/pools`);
-  return res.json();
+  const data = await res.json();
+  return data.map((item) => ({
+    city: item.city ?? item,
+    startsAt: item.startsAt ?? null,
+    isLive: item.isLive ?? false,
+  }));
 }
 
 export async function fetchLatest(city) {


### PR DESCRIPTION
## Summary
- join lottery pools with schedules and compute next start and live status
- expose pool schedule metadata via `fetchPools` and consume it on the live draw page
- cover schedule data in controller tests

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6895f194b8fc8328bf62cf1a51078e3a