### PR TITLE
feat: refresh results when countdown completes

### DIFF
--- a/frontend/src/components/CountdownTimer.jsx
+++ b/frontend/src/components/CountdownTimer.jsx
@@ -1,12 +1,23 @@
 import { useEffect, useState } from 'react';
 
-export default function CountdownTimer({ targetDate }) {
+export default function CountdownTimer({ targetDate, onComplete }) {
   const [now, setNow] = useState(Date.now());
 
   useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 1000);
+    const tick = () => {
+      const current = Date.now();
+      if (current >= targetDate) {
+        setNow(current);
+        clearInterval(id);
+        onComplete?.();
+      } else {
+        setNow(current);
+      }
+    };
+    const id = setInterval(tick, 1000);
+    tick();
     return () => clearInterval(id);
-  }, []);
+  }, [targetDate, onComplete]);
 
   const diff = Math.max(0, targetDate - now);
   const hrs = Math.floor(diff / 3600000);

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -34,6 +34,21 @@ export default function Home() {
 
   const heroNextDraw = nextDrawTimes.hero ? new Date(nextDrawTimes.hero) : null;
 
+  const refreshResults = () => {
+    Promise.all(
+      cities.map(city =>
+        fetchLatest(city).then(data => [city, data])
+      )
+    ).then(pairs => {
+      const map = Object.fromEntries(pairs);
+      setResults(map);
+      if (pairs.length) {
+        const [, firstData] = pairs[0];
+        setNextDrawTimes(prev => ({ ...prev, hero: firstData.nextDraw }));
+      }
+    });
+  };
+
   return (
     <div className="flex flex-col min-h-screen bg-gray-50">
       <Header />
@@ -51,7 +66,7 @@ export default function Home() {
               Result Angka Nusantara Pool
             </h1>
             {heroNextDraw ? (
-              <CountdownTimer targetDate={heroNextDraw} />
+              <CountdownTimer targetDate={heroNextDraw} onComplete={refreshResults} />
             ) : (
               <div className="h-12 w-48 bg-gray-700 animate-pulse rounded-md" />
             )}


### PR DESCRIPTION
## Summary
- trigger a callback when CountdownTimer reaches zero
- refresh city results after the countdown finishes to keep numbers current

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895fdf913a483289a17ae0af46c9da6