### PR TITLE
feat: include next draw timing

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -2,6 +2,9 @@ const jwt = require('jsonwebtoken');
 const prisma = require('../config/database');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+// Interval antar undian dalam menit. Default 60 menit.
+const DRAW_INTERVAL_MINUTES = parseInt(process.env.DRAW_INTERVAL_MINUTES || '60', 10);
+const DRAW_INTERVAL_MS = DRAW_INTERVAL_MINUTES * 60 * 1000;
 
 exports.listPools = async (req, res) => {
   try {
@@ -23,7 +26,9 @@ exports.latestByCity = async (req, res) => {
       orderBy: { drawDate: 'desc' },
     });
     if (!result) return res.status(404).json({ message: 'Not found' });
-    res.json(result);
+    // Hitung waktu undian berikutnya berdasarkan drawDate terakhir + interval
+    const nextDraw = new Date(result.drawDate.getTime() + DRAW_INTERVAL_MS);
+    res.json({ ...result, nextDraw });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -8,9 +8,7 @@ import { fetchPools, fetchLatest } from '../services/api';
 export default function Home() {
   const [cities, setCities] = useState([]);
   const [results, setResults] = useState({});
-  const [nextDrawTimes, setNextDrawTimes] = useState({});
   const [loading, setLoading] = useState(true);
-  const dummyNextDraw = new Date(Date.now() + 60 * 60 * 1000); // 1 jam dari sekarang
 
   // Ambil daftar kota dan hasil + nextDraw per kota
   useEffect(() => {
@@ -23,16 +21,13 @@ export default function Home() {
       ).then(pairs => {
         const map = Object.fromEntries(pairs);
         setResults(map);
-        // extract nextDraw untuk hero: pakai kota pertama
-        if (pairs.length) {
-          const [, firstData] = pairs[0];
-          setNextDrawTimes(prev => ({ ...prev, hero: firstData.nextDraw }));
-        }
       }).finally(() => setLoading(false));
     });
   }, []);
 
-  const heroNextDraw = nextDrawTimes.hero ? new Date(nextDrawTimes.hero) : null;
+  const heroNextDraw = results[cities[0]]?.nextDraw
+    ? new Date(results[cities[0]].nextDraw)
+    : null;
 
   return (
     <div className="flex flex-col min-h-screen bg-gray-50">


### PR DESCRIPTION
## Summary
- calculate next draw time for each city in `latestByCity` response
- drive hero countdown using the returned `nextDraw` data

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895fdfb88d88328879cd115174577c9