### PR TITLE
Broadcast live draw metadata events

### DIFF
--- a/backend/src/cron/fetchResults.js
+++ b/backend/src/cron/fetchResults.js
@@ -1,5 +1,5 @@
 const prisma = require('../config/database');
-const { logFetchError } = require('../controllers/lottery.controller');
+const { logFetchError, emitLiveMeta } = require('../controllers/lottery.controller');
 const { startLiveDraw } = require('../liveDraw');
 
 // lead time in minutes before draw when live draw should start
@@ -50,6 +50,7 @@ async function run() {
         }
         // end live draw once the result is processed
         activeLiveDraws.delete(s.city);
+        await emitLiveMeta(s.city, s);
       }
     }
     console.log('Draw job executed at', now);

--- a/backend/src/liveDraw.js
+++ b/backend/src/liveDraw.js
@@ -1,9 +1,11 @@
 const { getIO } = require('./io');
+const { emitLiveMeta } = require('./controllers/lottery.controller');
 
 async function startLiveDraw(city) {
   try {
     const io = getIO();
     io.emit('live-draw-start', { city });
+    await emitLiveMeta(city);
     console.log(`Live draw started for ${city}`);
   } catch (err) {
     console.error('[startLiveDraw] Failed to emit live draw start:', err);


### PR DESCRIPTION
## Summary
- emit `liveMeta` events with `{isLive, startsAt}` whenever schedules are created or updated
- broadcast `liveMeta` on live draw start and completion
- update scheduler to send `liveMeta` when draws finish

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6896005e44288328b7fcaaf91a9b6a4e