### PR TITLE
feat: standardize admin time display

### DIFF
--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -24,6 +24,7 @@ import {
     deletePool,
 
 } from '../services/api';
+import { formatTime, formatDateTime } from '../utils/time';
 
 export default function Admin() {
   const navigate = useNavigate();
@@ -309,7 +310,7 @@ function OverrideTable({ data }) {
           {data.map((o,i) => (
             <tr key={i} className={i%2===0 ? 'bg-white' : 'bg-gray-50'}>
               <td className="px-4 py-2">{o.city}</td>
-              <td className="px-4 py-2">{new Date(o.time).toLocaleString('id-ID', { timeZone: 'Asia/Jakarta' })}</td>
+              <td className="px-4 py-2">{formatDateTime(o.time)}</td>
               <td className="px-4 py-2">{o.oldNumbers}</td>
               <td className="px-4 py-2">{o.newNumbers}</td>
       <td className="px-4 py-2">{o.adminUsername}</td>
@@ -373,8 +374,8 @@ function ScheduleTable({ data, onDelete }) {
           {data.map((s, i) => (
             <tr key={i} className={i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
               <td className="px-4 py-2">{s.city}</td>
-              <td className="px-4 py-2">{s.closeTime}</td>
-              <td className="px-4 py-2">{s.drawTime}</td>
+              <td className="px-4 py-2">{formatTime(s.closeTime)}</td>
+              <td className="px-4 py-2">{formatTime(s.drawTime)}</td>
               <td className="px-4 py-2">
                 <button
                   onClick={() => onDelete(s.city)}

--- a/frontend/src/utils/time.js
+++ b/frontend/src/utils/time.js
@@ -1,0 +1,23 @@
+export function formatTime(timeStr) {
+  if (!timeStr) return '';
+  // Assume timeStr in 'HH:mm' format
+  const [hour = '', minute = ''] = timeStr.split(':');
+  const hh = hour.padStart(2, '0');
+  const mm = minute.padStart(2, '0');
+  return `${hh}:${mm} WIB`;
+}
+
+export function formatDateTime(dateStr) {
+  if (!dateStr) return '';
+  const date = new Date(dateStr);
+  const options = {
+    timeZone: 'Asia/Jakarta',
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  };
+  const formatted = new Intl.DateTimeFormat('id-ID', options).format(date);
+  return `${formatted} WIB`;
+}


### PR DESCRIPTION
## Summary
- add reusable time formatting helpers
- apply consistent timezone-aware formatting to schedule and override tables

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68960c6c8904832881a87c104906c3a4