### PR TITLE
Handle API errors and surface messages

### DIFF
--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -53,18 +53,22 @@ export default function Admin() {
   // Fetch admin data
   useEffect(() => {
     if (!token) return;
-    fetchStats(token)
-      .then(data => setStats(data))
-      .catch(err => console.error(err));
-    fetchPools(token)
-      .then(data => setPools(data))
-      .catch(err => console.error(err));
-    fetchRecentOverrides(token)
-      .then(data => setOverrides(Array.isArray(data) ? data : []))
-      .catch(err => console.error(err));
-          fetchSchedules(token)
-      .then(data => setSchedules(Array.isArray(data) ? data : []))
-      .catch(err => console.error(err));
+    (async () => {
+      try {
+        const [statsData, poolData, overrideData, scheduleData] = await Promise.all([
+          fetchStats(token),
+          fetchPools(token),
+          fetchRecentOverrides(token),
+          fetchSchedules(token),
+        ]);
+        setStats(statsData);
+        setPools(poolData);
+        setOverrides(Array.isArray(overrideData) ? overrideData : []);
+        setSchedules(Array.isArray(scheduleData) ? scheduleData : []);
+      } catch (err) {
+        setMessage({ text: err.message || 'Gagal memuat data', type: 'error' });
+      }
+    })();
   }, [token]);
 
   const handleAdd = async e => {

--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -195,6 +195,7 @@ export default function LiveDrawPage() {
   const [tickerItems, setTickerItems] = useState([]);
   const socketRef = useRef(null);
   const startRequestedRef = useRef(false);
+  const [error, setError] = useState(null);
 
   // --- Normalize city item coming from API ({ city, startsAt, isLive }) ---
   const normalizeCity = (item) => {
@@ -228,8 +229,14 @@ export default function LiveDrawPage() {
   // --- Initial fetch + pick best city (live or nearest) ---
   useEffect(() => {
     async function load() {
-      const list = await fetchPools();
-      setCities(Array.isArray(list) ? list : []);
+      try {
+        const list = await fetchPools();
+        setCities(Array.isArray(list) ? list : []);
+        setError(null);
+      } catch (err) {
+        console.error('Failed to load pools', err);
+        setError(err.message || 'Failed to load pools');
+      }
     }
     load();
   }, []);
@@ -338,7 +345,9 @@ export default function LiveDrawPage() {
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-br from-red-950 via-red-900 to-red-950 text-gray-100">
       <Header />
-
+      {error && (
+        <div className="bg-red-100 text-red-700 text-center py-2">{error}</div>
+      )}
       <main className="flex-1 px-4 py-6 sm:py-10">
         {/* Live banner + countdown */}
         <div className="max-w-4xl mx-auto w-full">

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -22,7 +22,7 @@ export default function Login() {
         setError(res.message || 'Login gagal');
       }
     } catch (err) {
-      setError('Terjadi kesalahan jaringan');
+      setError(err.message || 'Login gagal');
     }
   };
 

--- a/frontend/src/pages/SchedulePage.jsx
+++ b/frontend/src/pages/SchedulePage.jsx
@@ -5,9 +5,17 @@ import { fetchPublicSchedules } from '../services/api';
 
 export default function SchedulePage() {
   const [schedules, setSchedules] = useState([]);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    fetchPublicSchedules().then(setSchedules).catch(console.error);
+    (async () => {
+      try {
+        const data = await fetchPublicSchedules();
+        setSchedules(data);
+      } catch (err) {
+        setError(err.message || 'Gagal memuat jadwal');
+      }
+    })();
   }, []);
 
   return (
@@ -15,6 +23,7 @@ export default function SchedulePage() {
       <Header />
       <main className="flex-grow max-w-2xl mx-auto px-4 py-12">
         <h1 className="text-3xl font-bold text-center mb-6">Jadwal Penutupan &amp; Undian</h1>
+        {error && <p className="text-red-600 text-center mb-4">{error}</p>}
         <div className="overflow-x-auto bg-white shadow rounded-lg">
           <table className="min-w-full">
             <thead>

--- a/frontend/src/pages/StatsPage.jsx
+++ b/frontend/src/pages/StatsPage.jsx
@@ -9,15 +9,22 @@ export default function StatsPage() {
   const [stats, setStats] = useState(null);
   const [filterCity, setFilterCity] = useState('');
   const [cities, setCities] = useState([]);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    fetchStats().then(setStats).catch(console.error);
-    fetchAllHistory()
-      .then(data => {
-        setHistory(data);
-        setCities(Array.from(new Set(data.map(item => item.city))).sort());
-      })
-      .catch(console.error);
+    (async () => {
+      try {
+        const [statsData, historyData] = await Promise.all([
+          fetchStats(),
+          fetchAllHistory(),
+        ]);
+        setStats(statsData);
+        setHistory(historyData);
+        setCities(Array.from(new Set(historyData.map(item => item.city))).sort());
+      } catch (err) {
+        setError(err.message || 'Gagal memuat data');
+      }
+    })();
   }, []);
 
   const displayed = filterCity
@@ -38,6 +45,9 @@ export default function StatsPage() {
       <div className="flex-grow flex justify-center items-start py-16">
         <div className="w-full max-w-4xl bg-white rounded-3xl shadow-xl overflow-hidden">
           <main className="px-8 py-12 space-y-12">
+            {error && (
+              <div className="text-red-600 text-center mb-4">{error}</div>
+            )}
             {/* Title */}
             <div className="text-center">
               <h1 className="text-4xl font-extrabold text-primary mb-2">Statistik &amp; Riwayat Nusantara Full</h1>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,10 +1,22 @@
 // frontend/src/services/api.js
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
 
+async function handleResponse(res) {
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.json();
+      message = data?.message || message;
+    } catch {}
+    throw new Error(message);
+  }
+  return res.json();
+}
+
 // Public
 export async function fetchPools() {
   const res = await fetch(`${API_URL}/pools`);
-  const data = await res.json();
+  const data = await handleResponse(res);
   return data.map((item) => ({
     city: item.city ?? item,
     startsAt: item.startsAt ?? null,
@@ -14,10 +26,7 @@ export async function fetchPools() {
 
 export async function fetchLatest(city) {
   const res = await fetch(`${API_URL}/pools/${city}/latest`);
-  if (!res.ok) {
-    throw new Error(res.statusText);
-  }
-  const data = await res.json();
+  const data = await handleResponse(res);
   // ensure nextDraw gets passed along
   return {
     ...data,
@@ -31,10 +40,7 @@ export async function fetchAllLatest(cities = []) {
   const url = new URL(`${API_URL}/pools/latest`);
   if (cities.length) url.searchParams.set('cities', cities.join(','));
   const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(res.statusText);
-  }
-  const data = await res.json();
+  const data = await handleResponse(res);
   return data.map((item) => ({
     ...item,
     numbers: [item.firstPrize, item.secondPrize, item.thirdPrize],
@@ -49,7 +55,7 @@ export async function adminLogin(username, password) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password }),
   });
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function addPool(city, token) {
@@ -61,7 +67,7 @@ export async function addPool(city, token) {
     },
     body: JSON.stringify({ city }),
   });
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function overrideResults(city, drawDate, prizes, token) {
@@ -73,7 +79,7 @@ export async function overrideResults(city, drawDate, prizes, token) {
     },
     body: JSON.stringify({ drawDate, ...prizes }),
   });
-  return res.json();
+  return handleResponse(res);
 }
 
 // Recent Overrides
@@ -83,25 +89,25 @@ export async function fetchRecentOverrides(token, limit = 10) {
   const res = await fetch(url, {
     headers: { Authorization: `Bearer ${token}` },
   });
-  return res.json();
+  return handleResponse(res);
 }
 export async function fetchPublicSchedules() {
   const res = await fetch(`${API_URL}/schedules`);
-  return res.json();
+  return handleResponse(res);
 }
 // Dashboard Stats
 export async function fetchStats(token) {
   const res = await fetch(`${API_URL}/admin/stats`, {
     headers: { Authorization: `Bearer ${token}` },
   });
-  return res.json();
+  return handleResponse(res);
 }
 // Schedule management
 export async function fetchSchedules(token) {
   const res = await fetch(`${API_URL}/admin/schedules`, {
     headers: { Authorization: `Bearer ${token}` },
   });
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function createSchedule(city, drawTime, closeTime, token) {
@@ -113,7 +119,7 @@ export async function createSchedule(city, drawTime, closeTime, token) {
     },
     body: JSON.stringify({ city, drawTime, closeTime }),
   });
-  return res.json();
+  return handleResponse(res);
 }
 
 export async function updateSchedule(city, drawTime, closeTime, token) {
@@ -125,26 +131,27 @@ export async function updateSchedule(city, drawTime, closeTime, token) {
     },
     body: JSON.stringify({ drawTime, closeTime }),
   });
-  return res.json();
+  return handleResponse(res);
 }
 export async function deletePool(city, token) {
   const res = await fetch(`${API_URL}/admin/pools/${city}`, {
     method: 'DELETE',
     headers: { Authorization: `Bearer ${token}` },
   });
-  return res.json();
+  return handleResponse(res);
 }
 export async function deleteSchedule(city, token) {
   const res = await fetch(`${API_URL}/admin/schedules/${city}`, {
     method: 'DELETE',
     headers: { Authorization: `Bearer ${token}` },
   });
-  return res.json();
+  return handleResponse(res);
 }
 export async function fetchAllHistory() {
   const res = await fetch(`${API_URL}/history`);
-  const data = await res.json();
+  const data = await handleResponse(res);
   return data.map(item => ({
     ...item,
     numbers: [item.firstPrize, item.secondPrize, item.thirdPrize],
-  }));}
+  }));
+}


### PR DESCRIPTION
## Summary
- centralize API response handling with a helper that checks `res.ok` and extracts server error messages
- update service functions and pages (Admin, Login, Schedule, Stats, LiveDraw) to throw and display API errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68960c657d808328800c4c4e2990f3fc