### PR TITLE
Extend live draw timing intervals

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -359,7 +359,7 @@ exports.startLiveDraw = async (req, res) => {
 
   const drawPrize = (prizeIndex) => {
     if (prizeIndex >= prizeDefs.length) {
-      finalize();
+      setTimeout(finalize, 10 * 60 * 1000);
       return;
     }
     const prize = prizeDefs[prizeIndex];
@@ -373,9 +373,9 @@ exports.startLiveDraw = async (req, res) => {
           number: num,
         });
         if (idx === prize.value.length - 1) {
-          setTimeout(() => drawPrize(prizeIndex + 1), 1000);
+          setTimeout(() => drawPrize(prizeIndex + 1), 60000);
         }
-      }, idx * 1000);
+      }, idx * 60000);
     });
   };
 


### PR DESCRIPTION
## Summary
- slow live draw updates to once per minute and space prize rounds accordingly
- delay final live meta emission by ten minutes for longer result visibility

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689622fac6248328a26e75181fcd8021