### PR TITLE
Handle live draw start errors with retry

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,5 @@
+# Frontend
+
+## Live Draw Error Handling
+
+The live draw page automatically sends a request to start the draw when the countdown reaches zero. If this request fails, an error message will appear beneath the countdown along with a **Retry** button. Clicking **Retry** will attempt to start the live draw again.


### PR DESCRIPTION
## Summary
- add error handling and retry for live draw start request
- document live draw page error handling

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68963945dfec832886b5416906ae5795