### PR TITLE
Fix live draw route controller reference

### DIFF
--- a/backend/src/routes/lottery.routes.js
+++ b/backend/src/routes/lottery.routes.js
@@ -8,7 +8,7 @@ router.get('/pools',               ctrl.listPools);
 router.get('/pools/latest',        ctrl.latestMany);
 router.get('/pools/:city/latest',  ctrl.latestByCity);
 router.get('/history', ctrl.listAllHistory);
-router.post('/:city/live-draw', startLiveDraw);
+router.post('/:city/live-draw', ctrl.startLiveDraw);
 
 // Admin login
 router.post('/admin/login',        ctrl.login);


### PR DESCRIPTION
## Summary
- reference `startLiveDraw` via controller in lottery routes

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68975f590d548328a9507d1df3926a2e