### PR TITLE
Add pools segment to live draw route

### DIFF
--- a/backend/src/routes/lottery.routes.js
+++ b/backend/src/routes/lottery.routes.js
@@ -8,7 +8,7 @@ router.get('/pools',               ctrl.listPools);
 router.get('/pools/latest',        ctrl.latestMany);
 router.get('/pools/:city/latest',  ctrl.latestByCity);
 router.get('/history', ctrl.listAllHistory);
-router.post('/:city/live-draw', ctrl.startLiveDraw);
+router.post('/pools/:city/live-draw', ctrl.startLiveDraw);
 
 // Admin login
 router.post('/admin/login',        ctrl.login);


### PR DESCRIPTION
## Summary
- Correct live draw route path to `/pools/:city/live-draw`

## Testing
- `npm test`
- `curl -i -X POST http://localhost:4000/api/pools/jakarta/live-draw`

------
https://chatgpt.com/codex/tasks/task_e_689763e9d7988328a9ebdc2d4e11de28