### PR TITLE
Handle live draw conflict response

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -212,6 +212,12 @@ export default function LiveDrawPage() {
       const res = await fetch(`${API_URL}/pools/${cityId}/live-draw`, {
         method: 'POST',
       });
+      if (res.status === 409) {
+        const data = await res.json();
+        setError(data.error || 'Failed to start live draw');
+        startRequestedRef.current = false; // allow retry
+        return;
+      }
       if (!res.ok) throw new Error('Failed to start live draw');
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
## Summary
- Show the server-provided conflict message when attempting to start a live draw that's already in progress

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689767c560348328979c97bada2c5a95