### PR TITLE
refactor: share live draw state

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -2,6 +2,7 @@ const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 const prisma = require('../config/database');
 const { getIO } = require('../io');
+const { activeLiveDraws } = require('../liveDrawState');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 const ADMIN_USERNAME = process.env.ADMIN_USERNAME;
@@ -9,8 +10,6 @@ const ADMIN_PASSWORD_HASH = process.env.ADMIN_PASSWORD_HASH;
 
 // track timers for result expiration per city
 const resultExpireTimers = new Map();
-// track cities that currently have an active live draw
-const activeLiveDraws = new Set();
 
 function computeLiveMeta(schedule) {
   const now = jakartaDate();

--- a/backend/src/cron/fetchResults.js
+++ b/backend/src/cron/fetchResults.js
@@ -1,12 +1,11 @@
 const prisma = require('../config/database');
 const { logFetchError, emitLiveMeta } = require('../controllers/lottery.controller');
 const { startLiveDraw } = require('../liveDraw');
+const { activeLiveDraws } = require('../liveDrawState');
 
 // lead time in minutes before draw when live draw should start
 const LIVE_DRAW_LEAD_MINUTES = 5;
 
-// track cities that have an active live draw to avoid duplicates
-const activeLiveDraws = new Set();
 
 function jakartaNow() {
   const now = new Date();

--- a/backend/src/liveDrawState.js
+++ b/backend/src/liveDrawState.js
@@ -1,0 +1,3 @@
+const activeLiveDraws = new Set();
+
+module.exports = { activeLiveDraws };

--- a/backend/test/lottery.controller.test.js
+++ b/backend/test/lottery.controller.test.js
@@ -6,9 +6,11 @@ function loadController(mockPrisma, mockIO = { to() { return { emit() {} }; }, e
   const dbPath = path.resolve(__dirname, '../src/config/database.js');
   const ioPath = path.resolve(__dirname, '../src/io.js');
   const ctrlPath = path.resolve(__dirname, '../src/controllers/lottery.controller.js');
+  const statePath = path.resolve(__dirname, '../src/liveDrawState.js');
   // Inject mocks into require cache before requiring controller
   require.cache[dbPath] = { exports: mockPrisma };
   require.cache[ioPath] = { exports: { getIO: () => mockIO } };
+  require(statePath).activeLiveDraws.clear();
   delete require.cache[ctrlPath];
   return require(ctrlPath);
 }


### PR DESCRIPTION
## Summary
- centralize active live draw tracking in a shared module
- update lottery controller and cron job to use shared active draw state
- reset shared state in tests

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897678071a88328a64716db5da9f09f