### PR TITLE
feat(admin): add live draw tab

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,10 +1,11 @@
-import { Home, PlusCircle, RefreshCcw, Calendar } from 'lucide-react';
+import { Home, PlusCircle, RefreshCcw, Calendar, PlayCircle } from 'lucide-react';
 
 const menuItems = [
   { key: 'dashboard', name: 'Dashboard', icon: Home },
   { key: 'add',       name: 'Tambah Kota', icon: PlusCircle },
   { key: 'override',  name: 'Tentukan Hasil', icon: RefreshCcw },
   { key: 'schedule',  name: 'Jadwal', icon: Calendar },
+  { key: 'live-draw', name: 'Live Draw', icon: PlayCircle },
 
 ];
 

--- a/frontend/src/components/admin/LiveDrawTab.jsx
+++ b/frontend/src/components/admin/LiveDrawTab.jsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import { fetchPools } from '../../services/api';
+
+export default function LiveDrawTab({ token }) {
+  const [pools, setPools] = useState([]);
+  const [selectedCity, setSelectedCity] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchPools(token);
+        setPools(Array.isArray(data) ? data : []);
+      } catch (err) {
+        setMessage(err.message || 'Gagal memuat kota');
+      }
+    };
+    load();
+  }, [token]);
+
+  const refreshPools = async () => {
+    try {
+      const data = await fetchPools(token);
+      setPools(Array.isArray(data) ? data : []);
+    } catch {}
+  };
+
+  const handleStart = async () => {
+    if (!selectedCity) return;
+    try {
+      const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
+      await fetch(`${API_URL}/pools/${selectedCity}/live-draw`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setMessage(`Live draw ${selectedCity} dimulai`);
+      await refreshPools();
+    } catch (err) {
+      setMessage(err.message || 'Gagal memulai live draw');
+    }
+  };
+
+  const handleStop = async () => {
+    if (!selectedCity) return;
+    try {
+      const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
+      await fetch(`${API_URL}/pools/${selectedCity}/live-draw`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setMessage(`Live draw ${selectedCity} dihentikan`);
+      await refreshPools();
+    } catch (err) {
+      setMessage(err.message || 'Gagal menghentikan live draw');
+    }
+  };
+
+  const selectedPool = pools.find(p => p.city === selectedCity);
+
+  return (
+    <div className="bg-white rounded-lg shadow p-6 max-w-md mx-auto space-y-4">
+      <h4 className="text-xl font-semibold mb-4">Live Draw Manual</h4>
+      {message && <p className="text-sm text-gray-600">{message}</p>}
+      <select
+        className="w-full border rounded-lg px-4 py-2 focus:ring-primary focus:border-primary"
+        value={selectedCity}
+        onChange={e => setSelectedCity(e.target.value)}
+      >
+        <option value="">Pilih Kota</option>
+        {pools.map(p => (
+          <option key={p.city} value={p.city}>
+            {p.city} {p.isLive ? '(LIVE)' : ''}
+          </option>
+        ))}
+      </select>
+      <div className="flex space-x-4">
+        <button
+          onClick={handleStart}
+          disabled={!selectedCity}
+          className="bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-dark disabled:opacity-50"
+        >
+          Start
+        </button>
+        {selectedPool?.isLive && (
+          <button
+            onClick={handleStop}
+            className="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700"
+          >
+            Stop
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -7,6 +7,7 @@ import DashboardTab from '../components/admin/DashboardTab';
 import CityTab from '../components/admin/CityTab';
 import ScheduleTab from '../components/admin/ScheduleTab';
 import OverrideTab from '../components/admin/OverrideTab';
+import LiveDrawTab from '../components/admin/LiveDrawTab';
 import {
   fetchPools,
   fetchStats,
@@ -214,6 +215,7 @@ export default function Admin() {
               handleOverride={handleOverride}
             />
           )}
+          {activeTab === 'live-draw' && <LiveDrawTab token={token} />}
         </main>
       </div>
     </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -36,8 +36,13 @@ async function apiFetch(url, options = {}) {
 }
 
 // ===== Public =====
-export async function fetchPools() {
-  const data = await apiFetch(`${API_URL}/pools`);
+export async function fetchPools(token) {
+  const opts = token
+    ? {
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    : undefined;
+  const data = await apiFetch(`${API_URL}/pools`, opts);
   return data.map((item) => ({
     city: item.city ?? item,
     startsAt: item.startsAt ?? null,


### PR DESCRIPTION
## Summary
- add LiveDrawTab component to manually start or stop live draws
- expose Live Draw tab in admin dashboard and sidebar menu
- allow fetchPools to accept auth token

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68976f1c9bd883288879ddb85509c3ab