### PR TITLE
Validate live draw prize inputs

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -366,19 +366,19 @@ exports.startLiveDraw = async (req, res) => {
   try {
     const io = getIO();
 
-    // Helper to build an array of 6 digits from body or random number
-    const digitsFrom = (src) => {
-      const str =
-        typeof src === 'string' && /^\d{6}$/.test(src)
-          ? src
-          : String(Math.floor(Math.random() * 1000000)).padStart(6, '0');
-      return str.split('').map((d) => Number(d));
+    // Helper to build an array of 6 digits from provided prize number.
+    // Throws an error if the input is missing or not a six-digit string.
+    const digitsFrom = (src, name) => {
+      if (typeof src !== 'string' || !/^\d{6}$/.test(src)) {
+        throw new Error(`invalid ${name}`);
+      }
+      return src.split('').map((d) => Number(d));
     };
 
     const prizeDefs = [
-      { key: 'first', value: digitsFrom(req.body?.firstPrize) },
-      { key: 'second', value: digitsFrom(req.body?.secondPrize) },
-      { key: 'third', value: digitsFrom(req.body?.thirdPrize) },
+      { key: 'first', value: digitsFrom(req.body?.firstPrize, 'firstPrize') },
+      { key: 'second', value: digitsFrom(req.body?.secondPrize, 'secondPrize') },
+      { key: 'third', value: digitsFrom(req.body?.thirdPrize, 'thirdPrize') },
     ];
 
     const finalize = () => {
@@ -415,6 +415,9 @@ exports.startLiveDraw = async (req, res) => {
   } catch (err) {
     activeLiveDraws.delete(city);
     console.error('[startLiveDraw] Error:', err);
+    if (err.message && err.message.startsWith('invalid')) {
+      return res.status(400).json({ error: err.message });
+    }
     res.status(500).json({ error: 'internal server error' });
   }
 };

--- a/backend/test/lottery.controller.test.js
+++ b/backend/test/lottery.controller.test.js
@@ -91,7 +91,17 @@ test('startLiveDraw returns 409 if city already active', async () => {
   const origSetTimeout = global.setTimeout;
   global.setTimeout = () => 0;
   try {
-    await ctrl.startLiveDraw({ params: { city: 'jakarta' }, body: {} }, { json() {} });
+    await ctrl.startLiveDraw(
+      {
+        params: { city: 'jakarta' },
+        body: {
+          firstPrize: '123456',
+          secondPrize: '654321',
+          thirdPrize: '111111',
+        },
+      },
+      { json() {} }
+    );
     let status, body;
     const res = {
       status(code) {
@@ -102,7 +112,17 @@ test('startLiveDraw returns 409 if city already active', async () => {
         body = obj;
       },
     };
-    await ctrl.startLiveDraw({ params: { city: 'jakarta' }, body: {} }, res);
+    await ctrl.startLiveDraw(
+      {
+        params: { city: 'jakarta' },
+        body: {
+          firstPrize: '123456',
+          secondPrize: '654321',
+          thirdPrize: '111111',
+        },
+      },
+      res
+    );
     assert.equal(status, 409);
     assert.deepEqual(body, { error: 'live draw already in progress' });
   } finally {
@@ -121,7 +141,17 @@ test('startLiveDraw allows new draw after completion', async () => {
     return 0;
   };
   try {
-    await ctrl.startLiveDraw({ params: { city: 'jakarta' }, body: {} }, { json() {} });
+    await ctrl.startLiveDraw(
+      {
+        params: { city: 'jakarta' },
+        body: {
+          firstPrize: '123456',
+          secondPrize: '654321',
+          thirdPrize: '111111',
+        },
+      },
+      { json() {} }
+    );
     let status, body;
     const res = {
       status(code) {
@@ -132,10 +162,72 @@ test('startLiveDraw allows new draw after completion', async () => {
         body = obj;
       },
     };
-    await ctrl.startLiveDraw({ params: { city: 'jakarta' }, body: {} }, res);
+    await ctrl.startLiveDraw(
+      {
+        params: { city: 'jakarta' },
+        body: {
+          firstPrize: '222222',
+          secondPrize: '333333',
+          thirdPrize: '444444',
+        },
+      },
+      res
+    );
     assert.equal(status, undefined);
     assert.deepEqual(body, { message: 'live draw started', city: 'jakarta' });
   } finally {
     global.setTimeout = origSetTimeout;
   }
+});
+
+test('startLiveDraw returns 400 when a prize number is missing', async () => {
+  const mockPrisma = {};
+  const ctrl = loadController(mockPrisma);
+  let status, body;
+  const res = {
+    status(code) {
+      status = code;
+      return this;
+    },
+    json(obj) {
+      body = obj;
+    },
+  };
+  await ctrl.startLiveDraw(
+    {
+      params: { city: 'jakarta' },
+      body: { firstPrize: '123456', secondPrize: '654321' },
+    },
+    res
+  );
+  assert.equal(status, 400);
+  assert.deepEqual(body, { error: 'invalid thirdPrize' });
+});
+
+test('startLiveDraw returns 400 when a prize number is invalid', async () => {
+  const mockPrisma = {};
+  const ctrl = loadController(mockPrisma);
+  let status, body;
+  const res = {
+    status(code) {
+      status = code;
+      return this;
+    },
+    json(obj) {
+      body = obj;
+    },
+  };
+  await ctrl.startLiveDraw(
+    {
+      params: { city: 'jakarta' },
+      body: {
+        firstPrize: '12345a',
+        secondPrize: '654321',
+        thirdPrize: '111111',
+      },
+    },
+    res
+  );
+  assert.equal(status, 400);
+  assert.deepEqual(body, { error: 'invalid firstPrize' });
 });


### PR DESCRIPTION
## Summary
- Require six-digit numbers for all live draw prizes and return 400 on invalid input
- Add tests for missing or malformed prize numbers and update existing tests

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_689774d439648328b42d1e39f106e3f4