### PR TITLE
Persist live draw results

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -381,6 +381,46 @@ exports.startLiveDraw = async (req, res) => {
       { key: 'third', value: digitsFrom(req.body?.thirdPrize) },
     ];
 
+    // Join each prize's digits into a 6-digit string for persistence
+    const [firstPrize, secondPrize, thirdPrize] = prizeDefs.map((p) =>
+      p.value.join('')
+    );
+
+    const drawDate = jakartaDate();
+
+    // Fetch current numbers before update (if any)
+    const existing = await prisma.lotteryResult.findUnique({
+      where: { city_drawDate: { city, drawDate } },
+      select: { firstPrize: true, secondPrize: true, thirdPrize: true },
+    });
+
+    // Upsert the result with the new numbers
+    await prisma.lotteryResult.upsert({
+      where: { city_drawDate: { city, drawDate } },
+      update: { firstPrize, secondPrize, thirdPrize },
+      create: { city, drawDate, firstPrize, secondPrize, thirdPrize },
+    });
+
+    // Record that numbers were set via live draw
+    await prisma.override.create({
+      data: {
+        city,
+        oldNumbers:
+          [
+            existing?.firstPrize,
+            existing?.secondPrize,
+            existing?.thirdPrize,
+          ]
+            .filter(Boolean)
+            .join(','),
+        newNumbers: [firstPrize, secondPrize, thirdPrize].join(','),
+        adminUsername: req.user?.username || 'live-draw',
+      },
+    });
+
+    // Notify clients that this city's result has changed
+    io.emit('resultUpdated', { city });
+
     const finalize = () => {
       activeLiveDraws.delete(city);
       emitLiveMeta(city).catch(() => {});

--- a/backend/test/lottery.controller.test.js
+++ b/backend/test/lottery.controller.test.js
@@ -84,7 +84,15 @@ test('listPools returns schedule info', async () => {
 });
 
 test('startLiveDraw returns 409 if city already active', async () => {
-  const mockPrisma = {};
+  const mockPrisma = {
+    lotteryResult: {
+      findUnique: async () => null,
+      upsert: async () => ({}),
+    },
+    override: {
+      create: async () => ({}),
+    },
+  };
   const ctrl = loadController(mockPrisma);
 
   // Prevent scheduled callbacks from running so the draw stays active
@@ -111,7 +119,15 @@ test('startLiveDraw returns 409 if city already active', async () => {
 });
 
 test('startLiveDraw allows new draw after completion', async () => {
-  const mockPrisma = {};
+  const mockPrisma = {
+    lotteryResult: {
+      findUnique: async () => null,
+      upsert: async () => ({}),
+    },
+    override: {
+      create: async () => ({}),
+    },
+  };
   const ctrl = loadController(mockPrisma);
 
   // Execute timers immediately to finalize draw
@@ -135,6 +151,75 @@ test('startLiveDraw allows new draw after completion', async () => {
     await ctrl.startLiveDraw({ params: { city: 'jakarta' }, body: {} }, res);
     assert.equal(status, undefined);
     assert.deepEqual(body, { message: 'live draw started', city: 'jakarta' });
+  } finally {
+    global.setTimeout = origSetTimeout;
+  }
+});
+
+test('startLiveDraw persists numbers and logs override', async () => {
+  const upsertArgs = [];
+  const overrideArgs = [];
+  const ioEmits = [];
+  const mockPrisma = {
+    lotteryResult: {
+      findUnique: async () => null,
+      upsert: async (args) => {
+        upsertArgs.push(args);
+        return {};
+      },
+    },
+    override: {
+      create: async (args) => {
+        overrideArgs.push(args);
+        return {};
+      },
+    },
+  };
+  const mockIO = {
+    to() {
+      return { emit() {} };
+    },
+    emit(event, payload) {
+      ioEmits.push({ event, payload });
+    },
+  };
+  const ctrl = loadController(mockPrisma, mockIO);
+
+  const origSetTimeout = global.setTimeout;
+  global.setTimeout = (fn) => {
+    fn();
+    return 0;
+  };
+  try {
+    await ctrl.startLiveDraw(
+      {
+        params: { city: 'jakarta' },
+        body: {
+          firstPrize: '123456',
+          secondPrize: '234567',
+          thirdPrize: '345678',
+        },
+        user: { username: 'alice' },
+      },
+      { json() {} }
+    );
+
+    assert.equal(upsertArgs.length, 1);
+    const upsert = upsertArgs[0];
+    assert.equal(upsert.where.city_drawDate.city, 'jakarta');
+    assert.equal(upsert.update.firstPrize, '123456');
+    assert.equal(upsert.update.secondPrize, '234567');
+    assert.equal(upsert.update.thirdPrize, '345678');
+
+    assert.equal(overrideArgs.length, 1);
+    const override = overrideArgs[0];
+    assert.equal(override.data.city, 'jakarta');
+    assert.equal(override.data.newNumbers, '123456,234567,345678');
+    assert.equal(override.data.adminUsername, 'alice');
+
+    const emitted = ioEmits.find((e) => e.event === 'resultUpdated');
+    assert.ok(emitted);
+    assert.deepEqual(emitted.payload, { city: 'jakarta' });
   } finally {
     global.setTimeout = origSetTimeout;
   }


### PR DESCRIPTION
## Summary
- Persist live draw numbers by upserting lottery results and recording overrides
- Emit resultUpdated event when live draw numbers are saved
- Add tests confirming live draw populates lotteryResult and override tables

## Testing
- `cd backend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689774d6b9ec83288c77edc110d22f66