### PR TITLE
Adjust live draw to five digits

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -353,7 +353,7 @@ exports.overrideResults = async (req, res) => {
 };
 
 // Orchestrate a live draw with three prize rounds.
-// Each prize consists of six digits sent sequentially via Socket.IO.
+// Each prize now consists of five digits sent sequentially via Socket.IO.
 exports.startLiveDraw = async (req, res) => {
   const { city } = req.params;
 
@@ -366,10 +366,10 @@ exports.startLiveDraw = async (req, res) => {
   try {
     const io = getIO();
 
-    // Helper to build an array of 6 digits from provided prize number.
-    // Throws an error if the input is missing or not a six-digit string.
+    // Helper to build an array of 5 digits from provided prize number.
+    // Throws an error if the input is missing or not a five-digit string.
     const digitsFrom = (src, name) => {
-      if (typeof src !== 'string' || !/^\d{6}$/.test(src)) {
+      if (typeof src !== 'string' || !/^\d{5}$/.test(src)) {
         throw new Error(`invalid ${name}`);
       }
       return src.split('').map((d) => Number(d));
@@ -381,10 +381,10 @@ exports.startLiveDraw = async (req, res) => {
       { key: 'third', value: digitsFrom(req.body?.thirdPrize, 'thirdPrize') },
     ];
 
-    // Join each prize's digits into a 6-digit string for persistence
-    const [firstPrize, secondPrize, thirdPrize] = prizeDefs.map((p) =>
-      p.value.join('')
-    );
+      // Join each prize's digits into a 5-digit string for persistence
+      const [firstPrize, secondPrize, thirdPrize] = prizeDefs.map((p) =>
+        p.value.join('')
+      );
 
     const drawDate = jakartaDate();
 

--- a/backend/src/cron/fetchResults.js
+++ b/backend/src/cron/fetchResults.js
@@ -14,7 +14,7 @@ function jakartaNow() {
 }
 
 function generateNumber() {
-  return String(Math.floor(Math.random() * 1000000)).padStart(6, '0');
+  return String(Math.floor(Math.random() * 100000)).padStart(5, '0');
 }
 
 async function run() {

--- a/backend/test/lottery.controller.test.js
+++ b/backend/test/lottery.controller.test.js
@@ -103,9 +103,9 @@ test('startLiveDraw returns 409 if city already active', async () => {
       {
         params: { city: 'jakarta' },
         body: {
-          firstPrize: '123456',
-          secondPrize: '654321',
-          thirdPrize: '111111',
+          firstPrize: '12345',
+          secondPrize: '65432',
+          thirdPrize: '11111',
         },
       },
       { json() {} }
@@ -124,9 +124,9 @@ test('startLiveDraw returns 409 if city already active', async () => {
       {
         params: { city: 'jakarta' },
         body: {
-          firstPrize: '123456',
-          secondPrize: '654321',
-          thirdPrize: '111111',
+          firstPrize: '12345',
+          secondPrize: '65432',
+          thirdPrize: '11111',
         },
       },
       res
@@ -161,9 +161,9 @@ test('startLiveDraw allows new draw after completion', async () => {
       {
         params: { city: 'jakarta' },
         body: {
-          firstPrize: '123456',
-          secondPrize: '654321',
-          thirdPrize: '111111',
+          firstPrize: '12345',
+          secondPrize: '65432',
+          thirdPrize: '11111',
         },
       },
       { json() {} }
@@ -182,9 +182,9 @@ test('startLiveDraw allows new draw after completion', async () => {
       {
         params: { city: 'jakarta' },
         body: {
-          firstPrize: '222222',
-          secondPrize: '333333',
-          thirdPrize: '444444',
+          firstPrize: '22222',
+          secondPrize: '33333',
+          thirdPrize: '44444',
         },
       },
       res
@@ -235,9 +235,9 @@ test('startLiveDraw persists numbers and logs override', async () => {
       {
         params: { city: 'jakarta' },
         body: {
-          firstPrize: '123456',
-          secondPrize: '234567',
-          thirdPrize: '345678',
+          firstPrize: '12345',
+          secondPrize: '23456',
+          thirdPrize: '34567',
         },
         user: { username: 'alice' },
       },
@@ -247,14 +247,14 @@ test('startLiveDraw persists numbers and logs override', async () => {
     assert.equal(upsertArgs.length, 1);
     const upsert = upsertArgs[0];
     assert.equal(upsert.where.city_drawDate.city, 'jakarta');
-    assert.equal(upsert.update.firstPrize, '123456');
-    assert.equal(upsert.update.secondPrize, '234567');
-    assert.equal(upsert.update.thirdPrize, '345678');
+    assert.equal(upsert.update.firstPrize, '12345');
+    assert.equal(upsert.update.secondPrize, '23456');
+    assert.equal(upsert.update.thirdPrize, '34567');
 
     assert.equal(overrideArgs.length, 1);
     const override = overrideArgs[0];
     assert.equal(override.data.city, 'jakarta');
-    assert.equal(override.data.newNumbers, '123456,234567,345678');
+    assert.equal(override.data.newNumbers, '12345,23456,34567');
     assert.equal(override.data.adminUsername, 'alice');
 
     const emitted = ioEmits.find((e) => e.event === 'resultUpdated');
@@ -281,7 +281,7 @@ test('startLiveDraw returns 400 when a prize number is missing', async () => {
   await ctrl.startLiveDraw(
     {
       params: { city: 'jakarta' },
-      body: { firstPrize: '123456', secondPrize: '654321' },
+      body: { firstPrize: '12345', secondPrize: '65432' },
     },
     res
   );
@@ -306,9 +306,9 @@ test('startLiveDraw returns 400 when a prize number is invalid', async () => {
     {
       params: { city: 'jakarta' },
       body: {
-        firstPrize: '12345a',
-        secondPrize: '654321',
-        thirdPrize: '111111',
+        firstPrize: '1234a',
+        secondPrize: '65432',
+        thirdPrize: '11111',
       },
     },
     res

--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -160,7 +160,7 @@ function PrizeBox({ k, balls, active }) {
           >
             <span className="text-xs uppercase tracking-wider opacity-70">Kombinasi</span>
             <div className="text-xl sm:text-2xl font-black tabular-nums mt-1">
-              {result ? result : '— — — — — —'}
+              {result ? result : '— — — — —'}
             </div>
           </motion.div>
         </div>
@@ -187,7 +187,7 @@ export default function LiveDrawPage() {
   const [cities, setCities] = useState([]);
   const [selectedCity, setSelectedCity] = useState(null);
   const initialBalls = () =>
-    Array.from({ length: 6 }, () => ({ value: null, rolling: false }));
+    Array.from({ length: 5 }, () => ({ value: null, rolling: false }));
   const [prizes, setPrizes] = useState({
     first: initialBalls(),
     second: initialBalls(),
@@ -341,7 +341,7 @@ export default function LiveDrawPage() {
       setPrizes((prev) => {
         const updated = { ...prev, currentPrize: prize };
         // all balls start rolling until numbers are drawn
-        const arr = Array.from({ length: 6 }, () => ({ value: null, rolling: true }));
+        const arr = Array.from({ length: 5 }, () => ({ value: null, rolling: true }));
         updated[prize] = arr;
         return updated;
       });


### PR DESCRIPTION
## Summary
- update live draw controller to require and emit five digits per prize
- adapt cron job to generate five-digit numbers
- ensure frontend live draw UI expects five digits
- revise tests to check five-digit prizes

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689778d42dbc832898324d849f5acae4