### PR TITLE
fix: center prize balls in LiveDraw

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -142,7 +142,7 @@ function PrizeBox({ k, balls, active }) {
         <div className="mt-4 sm:mt-5">
           <div
             className={[
-              'grid grid-cols-6 xs:grid-cols-6 sm:grid-cols-6 gap-3 sm:gap-4',
+              'grid grid-cols-5 xs:grid-cols-5 sm:grid-cols-5 gap-3 sm:gap-4',
               'place-items-center',
               'px-1 sm:px-2',
             ].join(' ')}


### PR DESCRIPTION
## Summary
- ensure prize ball grid uses five columns so balls align centrally across breakpoints

## Testing
- `npm run build`
- `node verify-centering.js`

------
https://chatgpt.com/codex/tasks/task_e_68977ebfd5a88328bcaf0e2d647c8c7f