### PR TITLE
Use stored override results for live draws

### DIFF
--- a/backend/src/routes/lottery.routes.js
+++ b/backend/src/routes/lottery.routes.js
@@ -9,6 +9,7 @@ router.get('/pools/latest',        ctrl.latestMany);
 router.get('/pools/:city/latest',  ctrl.latestByCity);
 router.get('/history', ctrl.listAllHistory);
 router.post('/pools/:city/live-draw', ctrl.startLiveDraw);
+router.delete('/pools/:city/live-draw', ctrl.stopLiveDraw);
 
 // Admin login
 router.post('/admin/login',        ctrl.login);


### PR DESCRIPTION
## Summary
- Backend live draw now uses the latest override result instead of request digits and reports missing overrides
- Add endpoint to stop live draws
- Adjust tests for new live draw behaviour

## Testing
- `npm test`
- `npm test` *(frontend, fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68977ebb28808328af5b81b7950c0cb1