### PR TITLE
feat: allow admins to stop live draws

### DIFF
--- a/backend/src/routes/lottery.routes.js
+++ b/backend/src/routes/lottery.routes.js
@@ -9,6 +9,7 @@ router.get('/pools/latest',        ctrl.latestMany);
 router.get('/pools/:city/latest',  ctrl.latestByCity);
 router.get('/history', ctrl.listAllHistory);
 router.post('/pools/:city/live-draw', ctrl.startLiveDraw);
+router.delete('/pools/:city/live-draw', ctrl.stopLiveDraw);
 
 // Admin login
 router.post('/admin/login',        ctrl.login);

--- a/frontend/src/components/admin/LiveDrawTab.jsx
+++ b/frontend/src/components/admin/LiveDrawTab.jsx
@@ -44,11 +44,15 @@ export default function LiveDrawTab({ token }) {
     if (!selectedCity) return;
     try {
       const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
-      await fetch(`${API_URL}/pools/${selectedCity}/live-draw`, {
+      const res = await fetch(`${API_URL}/pools/${selectedCity}/live-draw`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` },
       });
-      setMessage(`Live draw ${selectedCity} dihentikan`);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || data.message || 'Gagal menghentikan live draw');
+      }
+      setMessage(data.message || `Live draw ${selectedCity} dihentikan`);
       await refreshPools();
     } catch (err) {
       setMessage(err.message || 'Gagal menghentikan live draw');


### PR DESCRIPTION
## Summary
- track live draw timers and allow manual stopping
- expose DELETE /pools/:city/live-draw endpoint
- surface server responses when stopping a live draw in admin UI

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68977ec912608328badd68d09a7770ab