### PR TITLE
feat: defer overrides and finalize live results

### DIFF
--- a/backend/prisma/migrations/20250809174358_add_draw_date_to_override/migration.sql
+++ b/backend/prisma/migrations/20250809174358_add_draw_date_to_override/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `drawDate` to the `Override` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Override" ADD COLUMN     "drawDate" TIMESTAMP(3) NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -29,10 +29,11 @@ model LotteryResult {
 model Override {
   id            Int      @id @default(autoincrement())
   city          String
+  drawDate      DateTime
   time          DateTime @default(now())   // timestamp override
-  oldNumbers    String                         
+  oldNumbers    String
   newNumbers    String
-  adminUsername String                         
+  adminUsername String
 
   @@index([time])                           // untuk query terbaru
 }


### PR DESCRIPTION
## Summary
- track the draw date on override records
- store admin overrides as drafts without touching results
- finalize live draw by upserting latest override and notifying clients

## Testing
- `npm test`
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" npx prisma migrate dev -n "add_drawDate_to_override"`


------
https://chatgpt.com/codex/tasks/task_e_68978751a3ac8328a62529968222f081