### PR TITLE
chore: handle drawDate migration

### DIFF
--- a/backend/prisma/migrations/20250809174358_add_draw_date_to_override/migration.sql
+++ b/backend/prisma/migrations/20250809174358_add_draw_date_to_override/migration.sql
@@ -1,8 +1,10 @@
 /*
   Warnings:
 
-  - Added the required column `drawDate` to the `Override` table without a default value. This is not possible if the table is not empty.
+  - Added the column `drawDate` to the `Override` table without a default value.
 
 */
 -- AlterTable
-ALTER TABLE "Override" ADD COLUMN     "drawDate" TIMESTAMP(3) NOT NULL;
+ALTER TABLE "Override" ADD COLUMN "drawDate" TIMESTAMP(3);
+UPDATE "Override" SET "drawDate" = NOW() WHERE "drawDate" IS NULL;
+ALTER TABLE "Override" ALTER COLUMN "drawDate" SET NOT NULL;


### PR DESCRIPTION
## Summary
- handle existing data when adding `drawDate` column to `Override` table

## Testing
- `npx prisma migrate deploy` *(fails: Can't reach database server at aws-0-ap-southeast-1.pooler.supabase.com:5432)*
- `npx prisma generate`
- `npm test` *(fails: startLiveDraw Error: override missing)*

------
https://chatgpt.com/codex/tasks/task_e_68979a5aec388328a8eb8012338a78bd