### PR TITLE
feat(frontend): restart countdown after completion

### DIFF
--- a/frontend/src/components/CountdownTimer.jsx
+++ b/frontend/src/components/CountdownTimer.jsx
@@ -1,12 +1,27 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
-export default function CountdownTimer({ targetDate }) {
+export default function CountdownTimer({ targetDate, onComplete }) {
   const [now, setNow] = useState(Date.now());
+  const intervalRef = useRef(null);
+  const completedRef = useRef(false);
 
   useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
+    intervalRef.current = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => clearInterval(intervalRef.current);
   }, []);
+
+  useEffect(() => {
+    const remaining = targetDate.getTime() - now;
+    if (remaining <= 0 && !completedRef.current) {
+      completedRef.current = true;
+      if (onComplete) {
+        onComplete();
+      }
+      clearInterval(intervalRef.current);
+    }
+  }, [now, onComplete, targetDate]);
 
   const diff = Math.max(0, targetDate.getTime() - now);
   const hrs = Math.floor(diff / 3600000);

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -62,6 +62,17 @@ export default function Home() {
   const showCountdown =
     heroNextClose instanceof Date && !isNaN(heroNextClose.valueOf());
 
+  const handleCountdownComplete = async () => {
+    try {
+      const latest = await fetchLatest(cityName);
+      setResults(prev => ({ ...prev, [cityName]: latest }));
+      setError(null);
+    } catch (err) {
+      console.error('Failed to fetch latest for', cityName, err);
+      setError(err.message || 'Failed to fetch latest');
+    }
+  };
+
   const heroNumbers = [
     heroData.firstPrize,
     heroData.secondPrize,
@@ -92,7 +103,12 @@ export default function Home() {
             </h1>
 
             {showCountdown
-              ? <CountdownTimer targetDate={heroNextClose} />
+              ? (
+                <CountdownTimer
+                  targetDate={heroNextClose}
+                  onComplete={handleCountdownComplete}
+                />
+              )
               : <div className="h-12 w-48 bg-gray-700 animate-pulse rounded-md" />
             }
 


### PR DESCRIPTION
## Summary
- add optional onComplete to CountdownTimer to clear interval and fire when timer hits zero
- refresh results and restart countdown on Home page when timer completes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897a63a9c488328b2cfc42602f47791