### PR TITLE
Include next-draw metadata in live updates

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -217,6 +217,7 @@ export default function LiveDrawPage() {
     currentPrize: '',
   });
   const [nextStartAt, setNextStartAt] = useState(null);
+  const [nextCloseAt, setNextCloseAt] = useState(null);
   const [countdown, setCountdown] = useState('');
   const [resultExpiresAt, setResultExpiresAt] = useState(null);
   const [tickerItems, setTickerItems] = useState([]);
@@ -440,9 +441,11 @@ export default function LiveDrawPage() {
       });
     });
 
-    socket.on('liveMeta', ({ isLive, startsAt, resultExpiresAt }) => {
-      // server optional: update meta agar countdown relevan
-      setNextStartAt(parseDate(startsAt) || null);
+    socket.on('liveMeta', ({ isLive, startsAt, nextClose, nextDraw, resultExpiresAt }) => {
+      // update meta so countdown & timers stay in sync with server schedule
+      const nextDrawDate = parseDate(nextDraw || startsAt) || null;
+      setNextStartAt(nextDrawDate);
+      setNextCloseAt(parseDate(nextClose) || null);
       setResultExpiresAt(resultExpiresAt || null);
       if (!resultExpiresAt) {
         setPrizes({
@@ -452,6 +455,7 @@ export default function LiveDrawPage() {
           currentPrize: '',
         });
       }
+      setCountdown(formatCountdown(nextDrawDate));
     });
 
     return () => socket.disconnect();


### PR DESCRIPTION
## Summary
- add nextClose & nextDraw to live meta payloads
- handle new liveMeta fields on LiveDraw page and recalc countdown
- cover live meta emission with a new test

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897c6321c9c83289785ff9799d48a86