### PR TITLE
Refresh pools after result expiration

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -349,7 +349,7 @@ export default function LiveDrawPage() {
   useEffect(() => {
     if (!resultExpiresAt) return;
     const delay = resultExpiresAt - Date.now();
-    if (delay <= 0) {
+    const resetAndReload = () => {
       setResultExpiresAt(null);
       setPrizes({
         first: initialBalls(),
@@ -357,17 +357,21 @@ export default function LiveDrawPage() {
         third: initialBalls(),
         currentPrize: '',
       });
+      (async () => {
+        try {
+          const list = await fetchPools();
+          setCities(Array.isArray(list) ? list : []);
+        } catch (err) {
+          console.error('Failed to reload pools', err);
+        }
+      })();
+    };
+
+    if (delay <= 0) {
+      resetAndReload();
       return;
     }
-    const t = setTimeout(() => {
-      setResultExpiresAt(null);
-      setPrizes({
-        first: initialBalls(),
-        second: initialBalls(),
-        third: initialBalls(),
-        currentPrize: '',
-      });
-    }, delay);
+    const t = setTimeout(resetAndReload, delay);
     return () => clearTimeout(t);
   }, [resultExpiresAt]);
 


### PR DESCRIPTION
## Summary
- Refresh pool list when live draw results expire to automatically switch to the next upcoming city

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6897ca83f74083289bdfc2b8c3f7a0af