### PR TITLE
Emit end-of-draw socket event and refresh client state

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -55,6 +55,12 @@ async function emitLiveMeta(city, scheduleOverride) {
         city,
         setTimeout(() => {
           resultExpireTimers.delete(city);
+          try {
+            const io = getIO();
+            io.to(city).emit('live-draw-end');
+          } catch (e) {
+            // ignore socket errors
+          }
           emitLiveMeta(city).catch(() => {});
         }, 10 * 60 * 1000)
       );

--- a/backend/test/live-draw-end.test.js
+++ b/backend/test/live-draw-end.test.js
@@ -1,0 +1,39 @@
+const assert = require('node:assert');
+const { test, mock } = require('node:test');
+const path = require('node:path');
+
+const events = [];
+
+// Stub modules before requiring controller
+require.cache[path.resolve(__dirname, '../src/io.js')] = {
+  exports: {
+    getIO: () => ({
+      to: () => ({
+        emit: (event, data) => {
+          events.push({ event, data });
+        },
+      }),
+    }),
+  },
+};
+
+require.cache[path.resolve(__dirname, '../src/config/database.js')] = {
+  exports: {
+    schedule: {
+      findUnique: async () => ({}),
+    },
+  },
+};
+
+const { emitLiveMeta } = require('../src/controllers/lottery.controller.js');
+
+mock.timers.enable({ apis: ['setTimeout'] });
+
+test('emits live-draw-end after result expiration', async () => {
+  await emitLiveMeta('jakarta', {});
+  assert(events.some((e) => e.event === 'liveMeta'));
+
+  mock.timers.tick(10 * 60 * 1000);
+
+  assert(events.some((e) => e.event === 'live-draw-end'));
+});

--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -473,6 +473,22 @@ export default function LiveDrawPage() {
       }
     });
 
+    socket.on('live-draw-end', async () => {
+      setPrizes({
+        first: initialBalls(),
+        second: initialBalls(),
+        third: initialBalls(),
+        currentPrize: '',
+      });
+      setResultExpiresAt(null);
+      try {
+        const list = await fetchPools();
+        setCities(Array.isArray(list) ? list : []);
+      } catch (err) {
+        console.error('Failed to reload pools', err);
+      }
+    });
+
     return () => socket.disconnect();
   }, []);
 


### PR DESCRIPTION
## Summary
- notify city rooms via `live-draw-end` when result window expires
- auto reset prizes and reload schedule on `live-draw-end` in LiveDrawPage
- add test ensuring `live-draw-end` emitted after result expiration

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6897ca828fd08328866e7ad2a27ff88d