### PR TITLE
Refresh schedule when countdown hits zero

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -385,6 +385,20 @@ export default function LiveDrawPage() {
       selectedCity &&
       !startRequestedRef.current
     ) {
+      (async () => {
+        try {
+          const cityId =
+            selectedCity.id ??
+            selectedCity.name ??
+            selectedCity.city ??
+            selectedCity;
+          const latest = await fetchLatest(cityId);
+          setNextDraw(parseDate(latest.nextDraw) || null);
+          setNextClose(parseDate(latest.nextClose) || null);
+        } catch (err) {
+          console.error('Failed to refresh schedule', err);
+        }
+      })();
       startLiveDraw();
     }
   }, [countdown, prizes.currentPrize, selectedCity]);


### PR DESCRIPTION
## Summary
- Fetch latest schedule when countdown hits zero with no active prize
- Update next draw and closing times so countdown restarts for next day

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897cf1056148328ac843b6bca246e93