### PR TITLE
Emit live draw end immediately after results

### DIFF
--- a/backend/test/live-draw-end.test.js
+++ b/backend/test/live-draw-end.test.js
@@ -29,11 +29,15 @@ const { emitLiveMeta } = require('../src/controllers/lottery.controller.js');
 
 mock.timers.enable({ apis: ['setTimeout'] });
 
-test('emits live-draw-end after result expiration', async () => {
-  await emitLiveMeta('jakarta', {});
+test('emits live-draw-end immediately after results', async () => {
+  await emitLiveMeta('jakarta', {}, true);
   assert(events.some((e) => e.event === 'liveMeta'));
+  assert(events.some((e) => e.event === 'live-draw-end'));
 
   mock.timers.tick(10 * 60 * 1000);
 
-  assert(events.some((e) => e.event === 'live-draw-end'));
+  await Promise.resolve();
+
+  // meta should be re-emitted after display period
+  assert(events.filter((e) => e.event === 'liveMeta').length >= 2);
 });


### PR DESCRIPTION
## Summary
- emit `live-draw-end` as soon as a draw finishes and broadcast refreshed metadata
- make display period configurable via `RESULT_DISPLAY_MS`
- adjust tests for new event timing

## Testing
- `node --test test/live-draw-end.test.js`
- `node --test test/lottery.controller.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897cf1885888328bec0c21de49cd14b