### PR TITLE
feat: pick next upcoming city

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -310,9 +310,31 @@ export default function LiveDrawPage() {
 
   useEffect(() => {
     if (!sortedCities.length) return;
-    // pilih: live duluan, kalau tidak ada live, pilih start paling dekat
-    const best = sortedCities[0];
-    setSelectedCity(best);
+    const nowTime = new Date();
+
+    // Prioritize live city if available
+    const live = sortedCities.find((c) => c.isLive);
+    if (live) {
+      setSelectedCity(live);
+      return;
+    }
+
+    // Find city with smallest positive time difference
+    let next = null;
+    let minDiff = Infinity;
+    for (const c of sortedCities) {
+      if (!c.startsAt) continue;
+      const diff = c.startsAt - nowTime;
+      if (diff > 0 && diff < minDiff) {
+        minDiff = diff;
+        next = c;
+      }
+    }
+
+    if (next) {
+      setSelectedCity(next);
+    }
+    // If all schedules passed, keep previous/ manual selection
   }, [sortedCities]);
 
   // --- Countdown (prioritaskan Pasaran Nusantara yg mau mulai) ---


### PR DESCRIPTION
## Summary
- select default city based on nearest upcoming start time
- keep current selection when all schedules are past

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6897d4947ca8832886246c4b2a16666a