### PR TITLE
Refresh schedule immediately after live draw

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -74,6 +74,11 @@ async function emitLiveMeta(city, scheduleOverride, justFinished = false) {
     }
 
     io.to(city).emit('liveMeta', meta);
+
+    if (justFinished) {
+      // immediately refresh meta for the upcoming schedule
+      setTimeout(() => emitLiveMeta(city).catch(() => {}), 0);
+    }
   } catch (err) {
     try {
       const io = getIO();

--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -227,6 +227,7 @@ export default function LiveDrawPage() {
   const [history, setHistory] = useState([]);
   const socketRef = useRef(null);
   const startRequestedRef = useRef(false);
+  const selectedCityRef = useRef(null);
   const [error, setError] = useState(null);
 
   const startLiveDraw = async () => {
@@ -328,6 +329,7 @@ export default function LiveDrawPage() {
 
   useEffect(() => {
     startRequestedRef.current = false;
+    selectedCityRef.current = selectedCity;
   }, [selectedCity, nextClose]);
 
   // fetch schedule when city changes
@@ -506,22 +508,13 @@ export default function LiveDrawPage() {
       });
       setResultExpiresAt(null);
       try {
-        const list = await fetchPools();
-        setCities(Array.isArray(list) ? list : []);
-      } catch (err) {
-        console.error('Failed to reload pools', err);
-      }
-    });
-
-    socket.on('live-draw-end', async () => {
-      setPrizes({
-        first: initialBalls(),
-        second: initialBalls(),
-        third: initialBalls(),
-        currentPrize: '',
-      });
-      setResultExpiresAt(null);
-      try {
+        const city = selectedCityRef.current;
+        if (city) {
+          const cityId = city.id ?? city.name ?? city.city ?? city;
+          const latest = await fetchLatest(cityId);
+          setNextDraw(parseDate(latest.nextDraw) || null);
+          setNextClose(parseDate(latest.nextClose) || null);
+        }
         const list = await fetchPools();
         setCities(Array.isArray(list) ? list : []);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Immediately re-emit live meta after results expire to show upcoming schedule.
- Refresh frontend schedule when `live-draw-end` fires by fetching latest data and pools.

## Testing
- `cd backend && npm test`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897d4a650208328867991e849572771