### PR TITLE
Refresh pools when live meta reset

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -504,22 +504,27 @@ export default function LiveDrawPage() {
     });
 
     // Unified liveMeta handler -> uses nextClose/nextDraw only
-    socket.on('liveMeta', ({ isLive, startsAt, nextClose, nextDraw, resultExpiresAt }) => {
-      const nd = parseDate(nextDraw || startsAt) || null; // fallback to startsAt if server omits nextDraw
-      const nc = parseDate(nextClose) || null;
-      setNextDraw(nd);
-      setNextClose(nc);
-      setResultExpiresAt(resultExpiresAt || null);
-      if (!resultExpiresAt) {
-        setPrizes({
-          first: initialBalls(),
-          second: initialBalls(),
-          third: initialBalls(),
-          currentPrize: '',
-        });
+    socket.on(
+      'liveMeta',
+      async ({ isLive, startsAt, nextClose, nextDraw, resultExpiresAt }) => {
+        const nd = parseDate(nextDraw || startsAt) || null; // fallback to startsAt if server omits nextDraw
+        const nc = parseDate(nextClose) || null;
+        setNextDraw(nd);
+        setNextClose(nc);
+        setResultExpiresAt(resultExpiresAt || null);
+        if (!resultExpiresAt) {
+          setPrizes({
+            first: initialBalls(),
+            second: initialBalls(),
+            third: initialBalls(),
+            currentPrize: '',
+          });
+          const list = await fetchPools();
+          setCities(Array.isArray(list) ? list : []);
+        }
+        // no direct setCountdown here; interval effect handles it from nextClose
       }
-      // no direct setCountdown here; interval effect handles it from nextClose
-    });
+    );
 
     socket.on('live-draw-end', async () => {
       setPrizes({


### PR DESCRIPTION
## Summary
- Make `liveMeta` socket handler async
- After resetting prizes when live results expire, refetch pools and update city list

## Testing
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897db3a2b60832885587f170ce92bb2