### PR TITLE
Rejoin room and refresh pools on socket reconnect

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -435,6 +435,19 @@ export default function LiveDrawPage() {
     const socket = socketIO(import.meta.env.VITE_SOCKET_URL || apiOrigin);
     socketRef.current = socket;
 
+    socket.on('connect', async () => {
+      const city = selectedCityRef.current;
+      if (city) {
+        const cityId = city.id ?? city.name ?? city.city ?? city;
+        socket.emit('joinLive', cityId);
+        const latest = await fetchLatest(cityId);
+        setNextDraw(parseDate(latest.nextDraw) || null);
+        setNextClose(parseDate(latest.nextClose) || null);
+      }
+      const list = await fetchPools();
+      setCities(Array.isArray(list) ? list : []);
+    });
+
     socket.on('prizeStart', ({ prize }) => {
       setPrizes((prev) => {
         const updated = { ...prev, currentPrize: prize };


### PR DESCRIPTION
## Summary
- Rejoin current pasaran and refresh list when socket reconnects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897db3bf9048328823ab31cc17c5f6d