### PR TITLE
Scope live-draw-start to city rooms

### DIFF
--- a/backend/src/liveDraw.js
+++ b/backend/src/liveDraw.js
@@ -4,7 +4,7 @@ const { emitLiveMeta } = require('./controllers/lottery.controller');
 async function startLiveDraw(city) {
   try {
     const io = getIO();
-    io.emit('live-draw-start', { city });
+    io.to(city).emit('live-draw-start', { city });
     await emitLiveMeta(city);
     console.log(`Live draw started for ${city}`);
   } catch (err) {

--- a/backend/test/live-draw-start.test.js
+++ b/backend/test/live-draw-start.test.js
@@ -1,0 +1,33 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const path = require('node:path');
+
+const events = [];
+
+// Stub modules before requiring startLiveDraw
+require.cache[path.resolve(__dirname, '../src/io.js')] = {
+  exports: {
+    getIO: () => ({
+      to: (room) => ({
+        emit: (event, data) => {
+          events.push({ room, event, data });
+        },
+      }),
+    }),
+  },
+};
+
+require.cache[path.resolve(__dirname, '../src/controllers/lottery.controller.js')] = {
+  exports: {
+    emitLiveMeta: async () => {},
+  },
+};
+
+const { startLiveDraw } = require('../src/liveDraw.js');
+
+test('emits live-draw-start only to specified city room', async () => {
+  await startLiveDraw('jakarta');
+  assert.deepStrictEqual(events, [
+    { room: 'jakarta', event: 'live-draw-start', data: { city: 'jakarta' } },
+  ]);
+});


### PR DESCRIPTION
## Summary
- Emit `live-draw-start` only to clients in the relevant city room using `io.to(city)`
- Add a unit test validating the room-scoped emission

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897e01de7e0832897514a6571d6b7e8