### PR TITLE
Delay schedule updates until draw completion or result expiry

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -394,6 +394,12 @@ export default function LiveDrawPage() {
         third: initialBalls(),
         currentPrize: '',
       });
+      const pending = pendingScheduleRef.current;
+      if (pending) {
+        setNextClose(pending.nextClose);
+        setNextDraw(pending.nextDraw);
+        pendingScheduleRef.current = null;
+      }
       (async () => {
         try {
           const list = await fetchPools();
@@ -533,7 +539,7 @@ export default function LiveDrawPage() {
         const nd = parseDate(nextDraw || startsAt) || null; // fallback to startsAt if server omits nextDraw
         const nc = parseDate(nextClose) || null;
         setResultExpiresAt(resultExpiresAt || null);
-        if (prizesRef.current.currentPrize) {
+        if (prizesRef.current.currentPrize || resultExpiresAt) {
           pendingScheduleRef.current = { nextClose: nc, nextDraw: nd };
         } else {
           pendingScheduleRef.current = null;


### PR DESCRIPTION
## Summary
- Defer next draw/close updates when a draw is running or results are still visible
- Apply stored schedule once results expire

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68986d5375588328be4c51e20733580e