### PR TITLE
Ensure final prize digits persist after draws

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -375,6 +375,26 @@ export default function LiveDrawPage() {
         const latest = await fetchLatest(cityId);
         setNextDraw(parseDate(latest.nextDraw) || null);
         setNextClose(parseDate(latest.nextClose) || null);
+        const toDigits = (v) =>
+          typeof v === 'string' || typeof v === 'number'
+            ? String(v)
+                .split('')
+                .map((d) => parseInt(d, 10))
+            : [];
+        const buildBalls = (digits) =>
+          Array.from({ length: 5 }, (_, i) => ({
+            value: digits[i] ?? null,
+            rolling: false,
+            remainingMs: 0,
+            totalMs: 0,
+          }));
+        setPrizes((prev) => ({
+          ...prev,
+          first: buildBalls(toDigits(latest.firstPrize)),
+          second: buildBalls(toDigits(latest.secondPrize)),
+          third: buildBalls(toDigits(latest.thirdPrize)),
+          currentPrize: '',
+        }));
       } catch (err) {
         console.error('Failed to fetch latest schedule', err);
       }
@@ -566,6 +586,26 @@ export default function LiveDrawPage() {
           const latest = await fetchLatest(cityId);
           setNextDraw(parseDate(latest.nextDraw) || null);
           setNextClose(parseDate(latest.nextClose) || null);
+          const toDigits = (v) =>
+            typeof v === 'string' || typeof v === 'number'
+              ? String(v)
+                  .split('')
+                  .map((d) => parseInt(d, 10))
+              : [];
+          const buildBalls = (digits) =>
+            Array.from({ length: 5 }, (_, i) => ({
+              value: digits[i] ?? null,
+              rolling: false,
+              remainingMs: 0,
+              totalMs: 0,
+            }));
+          setPrizes((prev) => ({
+            ...prev,
+            first: buildBalls(toDigits(latest.firstPrize)),
+            second: buildBalls(toDigits(latest.secondPrize)),
+            third: buildBalls(toDigits(latest.thirdPrize)),
+            currentPrize: '',
+          }));
         }
       } catch (err) {
         console.error('Failed to refresh schedule', err);


### PR DESCRIPTION
## Summary
- Parse prize numbers into digit arrays when fetching latest results for a selected city
- Update prizes state after live draw ends and reset `currentPrize` so final digits remain visible

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899c35c7ba48328805eb7ef18af7f6e