### PR TITLE
Refresh live draw history on updates

### DIFF
--- a/frontend/src/pages/LiveDrawPage.jsx
+++ b/frontend/src/pages/LiveDrawPage.jsx
@@ -254,6 +254,16 @@ export default function LiveDrawPage() {
     }
   };
 
+  const loadHistory = async () => {
+    try {
+      const data = await fetchAllHistory();
+      data.sort((a, b) => new Date(b.drawDate) - new Date(a.drawDate));
+      setHistory(data);
+    } catch (err) {
+      console.error('Failed to load history', err);
+    }
+  };
+
   // --- Normalize city item coming from API ({ city, startsAt, isLive }) ---
   const normalizeCity = (item) => {
     if (!item) return null;
@@ -299,15 +309,7 @@ export default function LiveDrawPage() {
   }, []);
 
   useEffect(() => {
-    (async () => {
-      try {
-        const data = await fetchAllHistory();
-        data.sort((a, b) => new Date(b.drawDate) - new Date(a.drawDate));
-        setHistory(data);
-      } catch (err) {
-        console.error('Failed to load history', err);
-      }
-    })();
+    loadHistory();
   }, []);
 
   useEffect(() => {
@@ -576,7 +578,10 @@ export default function LiveDrawPage() {
       } catch (err) {
         console.error('Failed to reload pools', err);
       }
+      await loadHistory();
     });
+
+    socket.on('resultUpdated', loadHistory);
 
     return () => socket.disconnect();
   }, []);


### PR DESCRIPTION
## Summary
- add loadHistory helper to centralize history fetch
- refresh history when live draw ends or result updates arrive

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c35e0af88328bc4669b1f1ae2073