### PR TITLE
feat: upsert result on override

### DIFF
--- a/backend/src/controllers/lottery.controller.js
+++ b/backend/src/controllers/lottery.controller.js
@@ -375,7 +375,7 @@ exports.overrideResults = async (req, res) => {
   const { city } = req.params;
   const { drawDate, firstPrize, secondPrize, thirdPrize } = req.body;
   try {
-        const date = jakartaDate(drawDate);
+    const date = jakartaDate(drawDate);
 
     // Fetch current numbers before update (if any)
     const existing = await prisma.lotteryResult.findUnique({
@@ -400,7 +400,15 @@ exports.overrideResults = async (req, res) => {
       },
     });
 
-    res.json(override);
+    const result = await prisma.lotteryResult.upsert({
+      where: { city_drawDate: { city, drawDate: date } },
+      update: { firstPrize, secondPrize, thirdPrize },
+      create: { city, drawDate: date, firstPrize, secondPrize, thirdPrize },
+    });
+
+    getIO().emit('resultUpdated', { city });
+
+    res.json({ override, result });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- persist override numbers directly to `lotteryResult`
- notify connected clients of updated results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a30b67d508328829684fa5a07c916